### PR TITLE
Add code-marker export spec and insert `// <EXPORT_BLOCK>` markers

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -4,6 +4,7 @@
 // Notes:
 // - Legacy single-task fields are kept temporarily for compatibility with existing UI/code.
 // - New systems should only use NodeState.Tasks.
+// <EXPORT_BLOCK>
 
 using System;
 using System.Collections.Generic;
@@ -173,3 +174,4 @@ namespace Core
         public List<string> News = new();
     }
 }
+// </EXPORT_BLOCK>

--- a/Assets/Scripts/Core/Sim.cs
+++ b/Assets/Scripts/Core/Sim.cs
@@ -4,6 +4,7 @@
 // Notes:
 // - Random incident generation is currently disabled via ENABLE_RANDOM_EVENTS.
 // - Events (PendingEvent) apply progress deltas to the most recent matching active task on the node.
+// <EXPORT_BLOCK>
 
 using System;
 using System.Collections.Generic;
@@ -458,3 +459,4 @@ namespace Core
         static int ClampInt(int v, int min, int max) => v < min ? min : (v > max ? max : v);
     }
 }
+// </EXPORT_BLOCK>

--- a/Assets/Scripts/Runtime/GameController.cs
+++ b/Assets/Scripts/Runtime/GameController.cs
@@ -6,6 +6,7 @@
 // - Assign/Busy/Cancel/Retreat all operate on NodeTask.
 // - Legacy APIs (TryAssignInvestigate/TryAssignContain/ForceWithdraw(nodeId)) are kept so existing UI can compile.
 //   They intentionally operate on a single "current" task per type to avoid creating invisible tasks before UI is upgraded.
+// <EXPORT_BLOCK>
 
 using System;
 using System.Collections.Generic;
@@ -438,3 +439,4 @@ public static class GameControllerTaskExt
         return AssignResult.Ok();
     }
 }
+// </EXPORT_BLOCK>

--- a/Assets/Scripts/UI/AgentPickerItemView.cs
+++ b/Assets/Scripts/UI/AgentPickerItemView.cs
@@ -1,3 +1,4 @@
+// <EXPORT_BLOCK>
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -91,3 +92,4 @@ public class AgentPickerItemView : MonoBehaviour
         if (attrText) attrText.color = selected ? new Color(0.2f, 0.2f, 0.2f) : new Color(0.8f, 0.8f, 0.8f);
     }
 }
+// </EXPORT_BLOCK>

--- a/Assets/Scripts/UI/AgentPickerView.cs
+++ b/Assets/Scripts/UI/AgentPickerView.cs
@@ -2,6 +2,7 @@
 // Source: Assets/Scripts/UI/AgentPickerView.cs
 // Updated for rule-set: 预定占用
 // - PreSelected agents stay BUSY (locked) even in current node.
+// <EXPORT_BLOCK>
 
 using System;
 using System.Collections.Generic;
@@ -190,3 +191,4 @@ public class AgentPickerView : MonoBehaviour
         Hide();
     }
 }
+// </EXPORT_BLOCK>

--- a/Assets/Scripts/UI/AnomalyManagePanel.cs
+++ b/Assets/Scripts/UI/AnomalyManagePanel.cs
@@ -8,6 +8,7 @@
 // Data scope note:
 // - Containables & post-containment management belong to the node that contained them.
 // - Global currency NegEntropy is accumulated in GameState, but per-anomaly state is stored under NodeState.
+// <EXPORT_BLOCK>
 
 using System;
 using System.Collections.Generic;
@@ -402,3 +403,4 @@ public class AnomalyManagePanel : MonoBehaviour
         return node.Tasks.LastOrDefault(t => t != null && t.Type == TaskType.Manage && t.TargetManagedAnomalyId == anomalyId);
     }
 }
+// </EXPORT_BLOCK>

--- a/Assets/Scripts/UI/NodePanelView.cs
+++ b/Assets/Scripts/UI/NodePanelView.cs
@@ -15,6 +15,7 @@
 //          - People (TMP_Text)
 //          - Btn_Action (Button)
 //             - Label (TMP_Text)
+// <EXPORT_BLOCK>
 
 using System;
 using System.Collections.Generic;
@@ -792,3 +793,4 @@ public class NodePanelView : MonoBehaviour
         return null;
     }
 }
+// </EXPORT_BLOCK>

--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -10,6 +10,7 @@
 // - Busy check still uses GameControllerTaskExt.AreAgentsBusy (global task scan).
 // - Contain requires node.Containables.Count > 0; target selection picks a containable not already targeted by an active contain task when possible.
 // - UI still uses ConfirmDialog for info prompts.
+// <EXPORT_BLOCK>
 
 using System;
 using System.Collections.Generic;
@@ -355,3 +356,4 @@ public class UIPanelRoot : MonoBehaviour
         return node.Containables[0].Id;
     }
 }
+// </EXPORT_BLOCK>

--- a/asset_manifest.json
+++ b/asset_manifest.json
@@ -1,0 +1,55 @@
+{
+  "type": "ProjectAgentExportSpec",
+  "version": 1,
+  "outputPath": "",
+  "exports": [
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/Runtime/GameController.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    },
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/Core/Sim.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    },
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/Core/GameState.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    },
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/UI/UIPanelRoot.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    },
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/UI/NodePanelView.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    },
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/UI/AgentPickerView.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    },
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/UI/AgentPickerItemView.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    },
+    {
+      "kind": "code_marker_block",
+      "file": "Assets/Scripts/UI/AnomalyManagePanel.cs",
+      "start": "// <EXPORT_BLOCK>",
+      "end": "// </EXPORT_BLOCK>"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a machine-readable export specification so downstream tools can extract specific code regions rather than whole files.
- Use marker-based extraction to allow precise exports of UI, runtime and core logic without changing runtime behavior.
- Target files were chosen to expose key runtime and UI components for automated tooling and code review workflows.

### Description
- Replace the previous asset manifest content with a `ProjectAgentExportSpec` JSON (`asset_manifest.json`) that lists `kind: code_marker_block` exports for the targeted files and uses `"start": "// <EXPORT_BLOCK>"` / `"end": "// </EXPORT_BLOCK>"` as boundaries.
- Insert `// <EXPORT_BLOCK>` and `// </EXPORT_BLOCK>` markers into the following files to delimit exportable regions: `Assets/Scripts/Runtime/GameController.cs`, `Assets/Scripts/Core/Sim.cs`, `Assets/Scripts/Core/GameState.cs`, `Assets/Scripts/UI/UIPanelRoot.cs`, `Assets/Scripts/UI/NodePanelView.cs`, `Assets/Scripts/UI/AgentPickerView.cs`, `Assets/Scripts/UI/AgentPickerItemView.cs`, and `Assets/Scripts/UI/AnomalyManagePanel.cs`.
- Keep all code semantics unchanged while adding only marker comments so extraction tools can safely parse the intended blocks.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968893ff3448322af3730a015cbc49e)