### PR TITLE
Fix manage panel node context refresh

### DIFF
--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -39,6 +39,7 @@ public class UIPanelRoot : MonoBehaviour
     private AgentPickerView _agentPicker;
     private ConfirmDialog _confirmDialog;
     private GameObject _managePanel;
+    private AnomalyManagePanel _managePanelView;
 
     private string _currentNodeId;
     private string _manageNodeId; // 当前打开的管理面板所对应的节点（与 NodePanel 的当前节点解耦）
@@ -260,6 +261,7 @@ public class UIPanelRoot : MonoBehaviour
             return;
         }
         _managePanel = Instantiate(managePanelPrefab, transform);
+        _managePanelView = _managePanel.GetComponent<AnomalyManagePanel>();
         _managePanel.SetActive(false);
     }
 
@@ -273,12 +275,12 @@ public class UIPanelRoot : MonoBehaviour
     // 兼容旧调用：若未传 nodeId，则默认使用当前打开的节点
     public void OpenManage()
     {
-        if (string.IsNullOrEmpty(_manageNodeId)) _manageNodeId = _currentNodeId;
-
         EnsureManagePanel();
         if (_managePanel)
         {
+            if (_managePanelView) _managePanelView.ShowForNode(_manageNodeId);
             _managePanel.SetActive(true);
+            if (_managePanelView) _managePanelView.ShowForNode(_manageNodeId);
             _managePanel.transform.SetAsLastSibling();
         }
     }


### PR DESCRIPTION
### Motivation
- The manage panel could show stale anomalies from the previous node because it relied on cached context instead of the `UIPanelRoot.ManageNodeId` and did not force a refresh when the panel was opened or hot-switched.
- The goal is to make the management UI always reflect the real source of truth (`NodeState.ManagedAnomalies`) and to ensure `OpenManage(nodeId)` immediately updates the panel content.
- Change scope is minimal and constrained to UI code only, avoiding prefab/YAML edits and reusing existing task APIs for dispatch/cancel.

### Description
- Cached the panel script instance by adding `_managePanelView` in `UIPanelRoot.cs` and obtain it after instantiating the `managePanelPrefab` via `GetComponent<AnomalyManagePanel>()`.
- Modified `UIPanelRoot.OpenManage()` to call `_managePanelView.ShowForNode(_manageNodeId)` both before and after `SetActive(true)` to force immediate refresh and to support hot-switching while visible, and preserved `ManageNodeId` handling without falling back to `CurrentNodeId`.
- Reworked `AnomalyManagePanel` to expose `public void ShowForNode(string nodeId)` and replaced internal `RefreshAll()`/`ResolveNodeContextIfNeeded()` usage with `RefreshUI()` that always reads node data from `GameController.I.GetNode(_nodeId)` and uses `NodeState.ManagedAnomalies` (via existing `GetFavoritedAnomalies`) as the data source.
- Ensured `OnEnable()` syncs `_nodeId` from `UIPanelRoot.I.ManageNodeId`, cleared stale selection when a node has no anomalies, and made selection/confirm logic call `RefreshUI()` so the UI reflects current node-scoped state; task dispatch/cancel still uses `CreateManageTask`/`AssignTask`/`CancelOrRetreatTask`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696904beaf008322a3f207948f5ba931)