### PR TITLE
Fix agent picker cancellation ordering

### DIFF
--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -352,11 +352,13 @@ public class UIPanelRoot : MonoBehaviour
         var taskId = _pickerTaskId;
         _pickerTaskId = null;
 
-        if (hidePicker && _agentPicker) _agentPicker.Hide();
-        if (string.IsNullOrEmpty(taskId) || GameController.I == null) return;
+        if (!string.IsNullOrEmpty(taskId) && GameController.I != null)
+        {
+            GameController.I.CancelOrRetreatTask(taskId);
+            RefreshNodePanel();
+        }
 
-        GameController.I.CancelOrRetreatTask(taskId);
-        RefreshNodePanel();
+        if (hidePicker && _agentPicker) _agentPicker.Hide();
     }
 
     // Pick a containable that is not already targeted by an active containment task when possible.


### PR DESCRIPTION
### Motivation
- Prevent a newly created picker-bound task from becoming a “ghost” when the AgentPicker is closed implicitly by ensuring the task is cancelled via `GameController.CancelOrRetreatTask` before hiding the picker, with a minimal single-file change to `Assets/Scripts/UI/UIPanelRoot.cs`.

### Description
- Reordered `ForceCancelPickerIfNeeded` to call `GameController.I.CancelOrRetreatTask(taskId)` and `RefreshNodePanel()` when `_pickerTaskId` is set, then hide the picker, and preserved clearing of `_pickerTaskId`; no prefabs or YAML files were modified.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690a456ea883228fc285897d676438)