### PR TITLE
Disable WebGL compression for GitHub Pages

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -566,7 +566,7 @@ PlayerSettings:
   webGLTemplate: APPLICATION:Default
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
-  webGLCompressionFormat: 0
+  webGLCompressionFormat: 2
   webGLWasmArithmeticExceptions: 0
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0


### PR DESCRIPTION
### Motivation
- Ensure WebGL builds are compatible with GitHub Pages by disabling Unity's WebGL compression so `.br`/`.gz` files (which require `Content-Encoding`) are not produced.

### Description
- Set `webGLCompressionFormat` to `2` (Disabled) in `ProjectSettings/ProjectSettings.asset`, changing `webGLCompressionFormat: 0` → `webGLCompressionFormat: 2` (1 line changed), and with compression disabled Unity will not emit `Build/*.br` artifacts.

### Testing
- No automated tests were run for this settings-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6d4d6238832293e1a5f30247c581)