### PR TITLE
Unify busy occupancy on tasks and migrate legacy ManagerAgentIds

### DIFF
--- a/Assets/Scripts/UI/AgentPickerView.cs
+++ b/Assets/Scripts/UI/AgentPickerView.cs
@@ -96,6 +96,7 @@ public class AgentPickerView : MonoBehaviour
     public void Hide()
     {
         gameObject.SetActive(false);
+        GameControllerTaskExt.LogBusySnapshot(GameController.I, "AgentPickerView.Hide");
     }
 
     void RefreshList(IEnumerable<AgentState> agents, Func<string, bool> isBusyOtherNode)
@@ -187,6 +188,7 @@ public class AgentPickerView : MonoBehaviour
     void OnCancelClicked()
     {
         // 取消就是不做任何改动，直接关闭
+        GameControllerTaskExt.LogBusySnapshot(GameController.I, "AgentPickerView.OnCancelClicked");
         _onCancel?.Invoke();
         Hide();
     }

--- a/Assets/Scripts/UI/AnomalyManagePanel.cs
+++ b/Assets/Scripts/UI/AnomalyManagePanel.cs
@@ -79,6 +79,7 @@ public class AnomalyManagePanel : MonoBehaviour
     public void Hide()
     {
         gameObject.SetActive(false);
+        GameControllerTaskExt.LogBusySnapshot(GameController.I, "AnomalyManagePanel.Hide");
     }
 
     public void ShowForNode(string nodeId)
@@ -160,7 +161,6 @@ public class AnomalyManagePanel : MonoBehaviour
             var nodeForLabel = (GameController.I != null && !string.IsNullOrEmpty(_nodeId)) ? GameController.I.GetNode(_nodeId) : null;
             var mtForLabel = FindManageTask(nodeForLabel, a.Id);
             if (mtForLabel?.AssignedAgentIds != null) mgr = mtForLabel.AssignedAgentIds.Count;
-            else if (a.ManagerAgentIds != null) mgr = a.ManagerAgentIds.Count; // legacy fallback
 
             if (label) label.text = BuildAnomalyLabel(a, mgr);
 
@@ -206,15 +206,6 @@ public class AnomalyManagePanel : MonoBehaviour
             foreach (var id in mt.AssignedAgentIds)
                 _selectedAgentIds.Add(id);
         }
-        else
-        {
-            var m = FindManagedAnomaly(node, anomalyId);
-            if (m?.ManagerAgentIds != null)
-            {
-                foreach (var id in m.ManagerAgentIds)
-                    _selectedAgentIds.Add(id);
-            }
-        }
 
         RefreshUI();
     }
@@ -242,8 +233,6 @@ public class AnomalyManagePanel : MonoBehaviour
         _selectedAgentIds.Clear();
         if (mt?.AssignedAgentIds != null)
             foreach (var id in mt.AssignedAgentIds) _selectedAgentIds.Add(id);
-        else if (anomaly.ManagerAgentIds != null)
-            foreach (var id in anomaly.ManagerAgentIds) _selectedAgentIds.Add(id);
 
         foreach (var ag in gc.State.Agents)
         {
@@ -353,7 +342,6 @@ public class AnomalyManagePanel : MonoBehaviour
         int mgr = 0;
         var mt = FindManageTask(node, m.Id);
         if (mt?.AssignedAgentIds != null) mgr = mt.AssignedAgentIds.Count;
-        else if (m.ManagerAgentIds != null) mgr = m.ManagerAgentIds.Count; // legacy fallback
         string nodeName = "";
         if (gc != null && !string.IsNullOrEmpty(_nodeId))
         {

--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -355,10 +355,15 @@ public class UIPanelRoot : MonoBehaviour
         if (!string.IsNullOrEmpty(taskId) && GameController.I != null)
         {
             GameController.I.CancelOrRetreatTask(taskId);
+            GameControllerTaskExt.LogBusySnapshot(GameController.I, $"UIPanelRoot.ForceCancelPickerIfNeeded(task:{taskId})");
             RefreshNodePanel();
         }
 
-        if (hidePicker && _agentPicker) _agentPicker.Hide();
+        if (hidePicker && _agentPicker)
+        {
+            GameControllerTaskExt.LogBusySnapshot(GameController.I, "UIPanelRoot.ForceCancelPickerIfNeeded(hidePicker)");
+            _agentPicker.Hide();
+        }
     }
 
     // Pick a containable that is not already targeted by an active containment task when possible.


### PR DESCRIPTION
### Motivation
- 移除对已弃用 legacy 占用字段 `ManagerAgentIds` 的写入，统一将占用状态由新模型 `NodeTask.AssignedAgentIds` 派生，以消除不同来源导致的占用不一致问题。 
- 保留对旧存档的兼容：一次性从 legacy 字段迁移出对应的 Manage 任务并清空 legacy，以避免运行时继续依赖旧字段。 
- 在关键路径加入可控调试日志与一致性校验，以便在 Debug/Development 模式下发现残留写入点或迁移缺失。

### Description
- 主要改动文件：
  - `Assets/Scripts/Runtime/GameController.cs`：删除了对 `ManagedAnomalyState.ManagerAgentIds` 的镜像写入（`AssignTask`/`CancelOrRetreatTask`），新增统一的 busy 派生 `DeriveBusyAgentIdsFromTasks`、调试快照 `LogBusySnapshot`、以及一次性迁移 `MigrateLegacyManageOccupancy`，并在 `Awake` 时触发迁移调用。 
  - `Assets/Scripts/UI/AnomalyManagePanel.cs`：移除所有依赖 legacy `ManagerAgentIds` 的读取回退，管理人数与选中干员均由对应的 Manage `NodeTask.AssignedAgentIds` 派生，并在面板关闭时写入 busy 快照日志。 
  - `Assets/Scripts/UI/AgentPickerView.cs`：在 picker 的隐藏/取消路径加入 `LogBusySnapshot` 调用以提供 picker 关闭时的占用快照。 
  - `Assets/Scripts/UI/UIPanelRoot.cs`：在强制回收/关闭 picker 的清理路径加入 busy 快照日志，便于观察取消/撤退后的占用收敛。 
- 行为要点：
  - 全局 busy 判断由 `GameControllerTaskExt.DeriveBusyAgentIdsFromTasks` 计算的 active task 派生集合决定，`AreAgentsBusy` 不再读取 legacy 字段。 
  - 兼容迁移：若存在 legacy `ManagerAgentIds`，在首次初始化时为对应 anomaly 创建或补全一个 `TaskType.Manage` 的 active 任务并将 legacy agent ids 迁入，再清空 legacy 列表；若已有对应 manage task 且 agent 列表与 legacy 不一致，则在 `UNITY_EDITOR`/`DEVELOPMENT_BUILD` 下打印 WARNING 以便排查。 
  - 在任务创建、分配、取消/撤退、picker/面板关闭、强制回收等关键点输出一致的 `[BusySnapshot]` 日志，并在 Debug 模式下对比 legacy 值并在不一致时打印 WARNING。 

### Testing
- 运行全文检索确保残留写入点最小化：执行 `rg "ManagerAgentIds|LegacyBusyAgentIds" Assets/Scripts -S`，命令返回并定位到已更新的代码位置（成功）。
- 查看变更并提交：执行 `git status --short`、`git diff` 与 `git commit -m "Unify busy derivation on tasks and migrate legacy manage occupancy"`，提交成功（成功）。
- 验证提交详情：执行 `git show -1 --stat` 并确认修改记录包含预期文件与行数（成功）。

如果需要，我可以继续：运行 Unity 编辑器编译检测、添加单元测试以覆盖 `DeriveBusyAgentIdsFromTasks`/`MigrateLegacyManageOccupancy`，或把 `BusySnapshot` 的输出等级/格式调整为更适合生产日志的形式。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69747584a39c8322ab2636ed23bb676a)