### PR TITLE
Fix escaped string.Join delimiters causing C# parse errors

### DIFF
--- a/Assets/Scripts/Runtime/GameController.cs
+++ b/Assets/Scripts/Runtime/GameController.cs
@@ -203,7 +203,7 @@ public class GameController : MonoBehaviour
             n.Status = NodeStatus.Calm;
 
 
-        GameControllerTaskExt.LogBusySnapshot(this, $"AssignTask(task:{taskId}, agents:{string.Join(\",\", agentIds)})");
+        GameControllerTaskExt.LogBusySnapshot(this, $"AssignTask(task:{taskId}, agents:{string.Join(",", agentIds)})");
         Notify();
     }
 
@@ -280,7 +280,7 @@ public static class GameControllerTaskExt
         bool anyBusy = agentIds.Any(id => !string.IsNullOrEmpty(id) && busy.Contains(id));
         if (anyBusy)
 
-            LogBusySnapshot(gc, $"AreAgentsBusy(check:{string.Join(\",\", agentIds)})");
+            LogBusySnapshot(gc, $"AreAgentsBusy(check:{string.Join(",", agentIds)})");
         return anyBusy;
     }
 
@@ -399,7 +399,7 @@ public static class GameControllerTaskExt
         // Assign squad
         current.AssignedAgentIds = new List<string>(agentIds);
 
-        LogBusySnapshot(gc, $"TryAssignLegacyCurrentTask(node:{nodeId}, type:{type}, agents:{string.Join(\",\", agentIds)})");
+        LogBusySnapshot(gc, $"TryAssignLegacyCurrentTask(node:{nodeId}, type:{type}, agents:{string.Join(",", agentIds)})");
 
         return AssignResult.Ok();
     }
@@ -512,7 +512,7 @@ public static class GameControllerTaskExt
                     if (!taskSet.SetEquals(legacySet))
                     {
 
-                        Debug.LogWarning($"[LegacyManageMigration] Existing task differs anomaly:{anomaly.Id} task:[{string.Join(\",\", taskSet)}] legacy:[{string.Join(\",\", legacySet)}]");
+                        Debug.LogWarning($"[LegacyManageMigration] Existing task differs anomaly:{anomaly.Id} task:[{string.Join(",", taskSet)}] legacy:[{string.Join(",", legacySet)}]");
 
                     }
 #endif
@@ -534,7 +534,7 @@ public static class GameControllerTaskExt
                     };
                     node.Tasks.Add(task);
 
-                    Debug.Log($"[LegacyManageMigration] Created manage task for anomaly:{anomaly.Id} agents:{string.Join(\",\", legacyAgents)}");
+                    Debug.Log($"[LegacyManageMigration] Created manage task for anomaly:{anomaly.Id} agents:{string.Join(",", legacyAgents)}");
 
                 }
                 else
@@ -543,7 +543,7 @@ public static class GameControllerTaskExt
                     foreach (var id in legacyAgents)
                         if (!task.AssignedAgentIds.Contains(id)) task.AssignedAgentIds.Add(id);
 
-                    Debug.Log($"[LegacyManageMigration] Patched manage task:{task.Id} anomaly:{anomaly.Id} agents:{string.Join(\",\", task.AssignedAgentIds)}");
+                    Debug.Log($"[LegacyManageMigration] Patched manage task:{task.Id} anomaly:{anomaly.Id} agents:{string.Join(",", task.AssignedAgentIds)}");
 
                 }
 


### PR DESCRIPTION
### Motivation
- Escaped quote delimiters were present in `string.Join` calls inside `Assets/Scripts/Runtime/GameController.cs`, which produced unterminated/interpolated string literal syntax errors in logging statements.

### Description
- Replace the malformed escaped delimiter sequences in `string.Join` calls with a plain `","` delimiter in all affected logging/interpolated strings in `GameController.cs`, restoring valid C# interpolated string literals.

### Testing
- Ran `rg 'string.Join\("' Assets/Scripts/Runtime/GameController.cs` to ensure no occurrences of the malformed escaped delimiter remain (no matches).
- Inspected the updated file sections to verify logging lines now use `string.Join(",", ...)` where applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69747aef37148322841b7a6ef534eba1)