### PR TITLE
MVP: Node‑scoped event system stubs (P0‑4, Editor/WebGL safe)

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -14,7 +14,7 @@ namespace Core
     // Keep for legacy UI and map display. In N-task model, task state is derived from NodeState.Tasks.
     public enum NodeStatus { Calm, Secured }
 
-    // Events still attach to a node; their kind affects which task type they modify.
+    // Legacy event kind (PendingEvent). New node events use EventSource/EventInstance.
     public enum EventKind { Investigate, Contain }
 
     public enum TaskType { Investigate, Contain, Manage }
@@ -112,6 +112,11 @@ namespace Core
 
         // ===== NEW: Unlimited tasks =====
         public List<NodeTask> Tasks = new();
+
+        // ===== Node-scoped state =====
+        public int LocalPanic = 0;
+        public int Population = 10;
+        public List<EventInstance> PendingEvents = new();
 
         // ===== Legacy fields (temporary) =====
         // Kept so existing UI/code can compile during migration. Do not use for new features.

--- a/Assets/Scripts/Core/NodeEvents.cs
+++ b/Assets/Scripts/Core/NodeEvents.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Core
+{
+    public enum EventSource
+    {
+        Investigate,
+        Contain,
+        LocalPanicHigh,
+        Fixed,
+        SecuredManage,
+        Random
+    }
+
+    [Serializable]
+    public class EventEffect
+    {
+        public int LocalPanicDelta = 0;
+        public int PopulationDelta = 0;
+        public int GlobalPanicDelta = 0;
+        public int MoneyDelta = 0;
+        public int NegEntropyDelta = 0;
+
+        public override string ToString()
+        {
+            return $"LocalPanicDelta={LocalPanicDelta},PopulationDelta={PopulationDelta},GlobalPanicDelta={GlobalPanicDelta},MoneyDelta={MoneyDelta},NegEntropyDelta={NegEntropyDelta}";
+        }
+    }
+
+    [Serializable]
+    public class EventOption
+    {
+        public string OptionId;
+        public string Text;
+        public EventEffect Effects = new EventEffect();
+    }
+
+    [Serializable]
+    public class EventInstance
+    {
+        public string EventId;
+        public EventSource Source;
+        public string NodeId;
+        public string Title;
+        public string Desc;
+        public List<EventOption> Options = new();
+        public int CreatedDay;
+        public EventEffect IgnorePenalty = new EventEffect();
+    }
+
+    [Serializable]
+    public class EventTemplate
+    {
+        public EventSource Source;
+        public string Title;
+        public string Desc;
+        public List<EventOption> Options = new();
+        public EventEffect IgnorePenalty = new EventEffect();
+    }
+
+    public static class EventTemplates
+    {
+        private static readonly List<EventTemplate> Templates = new()
+        {
+            BuildInvestigate(),
+            BuildContain(),
+            BuildLocalPanicHigh(),
+            BuildFixed(),
+            BuildSecuredManage(),
+            BuildRandom(),
+        };
+
+        public static EventInstance CreateInstance(EventSource source, string nodeId, int day, Random rng)
+        {
+            var template = PickTemplate(source, rng);
+            if (template == null) return null;
+
+            return new EventInstance
+            {
+                EventId = $"EV_{Guid.NewGuid().ToString("N")[..8]}",
+                Source = source,
+                NodeId = nodeId,
+                Title = template.Title,
+                Desc = template.Desc,
+                Options = template.Options.Select(CloneOption).ToList(),
+                CreatedDay = day,
+                IgnorePenalty = CloneEffect(template.IgnorePenalty)
+            };
+        }
+
+        private static EventTemplate PickTemplate(EventSource source, Random rng)
+        {
+            var candidates = Templates.Where(t => t != null && t.Source == source).ToList();
+            if (candidates.Count == 0) return null;
+            if (rng == null || candidates.Count == 1) return candidates[0];
+            return candidates[rng.Next(candidates.Count)];
+        }
+
+        private static EventOption CloneOption(EventOption opt)
+        {
+            if (opt == null) return null;
+            return new EventOption
+            {
+                OptionId = opt.OptionId,
+                Text = opt.Text,
+                Effects = CloneEffect(opt.Effects)
+            };
+        }
+
+        private static EventEffect CloneEffect(EventEffect eff)
+        {
+            if (eff == null) return new EventEffect();
+            return new EventEffect
+            {
+                LocalPanicDelta = eff.LocalPanicDelta,
+                PopulationDelta = eff.PopulationDelta,
+                GlobalPanicDelta = eff.GlobalPanicDelta,
+                MoneyDelta = eff.MoneyDelta,
+                NegEntropyDelta = eff.NegEntropyDelta
+            };
+        }
+
+        private static EventTemplate BuildInvestigate()
+        {
+            return new EventTemplate
+            {
+                Source = EventSource.Investigate,
+                Title = "调查引发关注",
+                Desc = "调查行动被目击，媒体开始追问。",
+                IgnorePenalty = new EventEffect { LocalPanicDelta = 2, PopulationDelta = -1 },
+                Options = new List<EventOption>
+                {
+                    new EventOption
+                    {
+                        OptionId = "INV_CALM",
+                        Text = "低调安抚目击者",
+                        Effects = new EventEffect { LocalPanicDelta = -1, PopulationDelta = 0 }
+                    },
+                    new EventOption
+                    {
+                        OptionId = "INV_FORCE",
+                        Text = "强硬封锁消息",
+                        Effects = new EventEffect { LocalPanicDelta = -2, PopulationDelta = -1, GlobalPanicDelta = 1 }
+                    }
+                }
+            };
+        }
+
+        private static EventTemplate BuildContain()
+        {
+            return new EventTemplate
+            {
+                Source = EventSource.Contain,
+                Title = "收容现场余波",
+                Desc = "收容过程造成附带损失，需要后续处理。",
+                IgnorePenalty = new EventEffect { LocalPanicDelta = 2, PopulationDelta = -1 },
+                Options = new List<EventOption>
+                {
+                    new EventOption
+                    {
+                        OptionId = "CON_REPAIR",
+                        Text = "优先修复与善后",
+                        Effects = new EventEffect { LocalPanicDelta = -1, MoneyDelta = -50 }
+                    },
+                    new EventOption
+                    {
+                        OptionId = "CON_PUSH",
+                        Text = "压下损失继续推进",
+                        Effects = new EventEffect { LocalPanicDelta = 1, PopulationDelta = -1, MoneyDelta = 50 }
+                    }
+                }
+            };
+        }
+
+        private static EventTemplate BuildLocalPanicHigh()
+        {
+            return new EventTemplate
+            {
+                Source = EventSource.LocalPanicHigh,
+                Title = "本地恐慌蔓延",
+                Desc = "恐慌已接近失控，社区秩序开始崩坏。",
+                IgnorePenalty = new EventEffect { LocalPanicDelta = 3, PopulationDelta = -1, GlobalPanicDelta = 1 },
+                Options = new List<EventOption>
+                {
+                    new EventOption
+                    {
+                        OptionId = "LP_PUBLIC",
+                        Text = "公开安抚与物资投放",
+                        Effects = new EventEffect { LocalPanicDelta = -2, MoneyDelta = -80 }
+                    },
+                    new EventOption
+                    {
+                        OptionId = "LP_LOCKDOWN",
+                        Text = "强制管制区域",
+                        Effects = new EventEffect { LocalPanicDelta = -1, PopulationDelta = -1 }
+                    }
+                }
+            };
+        }
+
+        private static EventTemplate BuildFixed()
+        {
+            return new EventTemplate
+            {
+                Source = EventSource.Fixed,
+                Title = "预定演习事故",
+                Desc = "例行演习中发生误报，公众开始质疑机构能力。",
+                IgnorePenalty = new EventEffect { LocalPanicDelta = 2, GlobalPanicDelta = 1 },
+                Options = new List<EventOption>
+                {
+                    new EventOption
+                    {
+                        OptionId = "FX_APOLOGY",
+                        Text = "发布正式说明",
+                        Effects = new EventEffect { LocalPanicDelta = -1, MoneyDelta = -30 }
+                    },
+                    new EventOption
+                    {
+                        OptionId = "FX_SPIN",
+                        Text = "转移舆论焦点",
+                        Effects = new EventEffect { LocalPanicDelta = 0, GlobalPanicDelta = 1, MoneyDelta = 30 }
+                    }
+                }
+            };
+        }
+
+        private static EventTemplate BuildSecuredManage()
+        {
+            return new EventTemplate
+            {
+                Source = EventSource.SecuredManage,
+                Title = "管理流程审计",
+                Desc = "已收容异常的管理流程被抽查，需要即时回应。",
+                IgnorePenalty = new EventEffect { LocalPanicDelta = 1, NegEntropyDelta = -1 },
+                Options = new List<EventOption>
+                {
+                    new EventOption
+                    {
+                        OptionId = "SM_COMPLY",
+                        Text = "全面配合审计",
+                        Effects = new EventEffect { LocalPanicDelta = -1, NegEntropyDelta = -1 }
+                    },
+                    new EventOption
+                    {
+                        OptionId = "SM_HIDE",
+                        Text = "压缩审计范围",
+                        Effects = new EventEffect { LocalPanicDelta = 1, NegEntropyDelta = 1 }
+                    }
+                }
+            };
+        }
+
+        private static EventTemplate BuildRandom()
+        {
+            return new EventTemplate
+            {
+                Source = EventSource.Random,
+                Title = "偶发目击报告",
+                Desc = "匿名举报称发现异常活动，需要选择响应策略。",
+                IgnorePenalty = new EventEffect { LocalPanicDelta = 1 },
+                Options = new List<EventOption>
+                {
+                    new EventOption
+                    {
+                        OptionId = "RD_VERIFY",
+                        Text = "谨慎核查",
+                        Effects = new EventEffect { LocalPanicDelta = -1, MoneyDelta = -20 }
+                    },
+                    new EventOption
+                    {
+                        OptionId = "RD_SWEEP",
+                        Text = "快速清场",
+                        Effects = new EventEffect { LocalPanicDelta = 1, PopulationDelta = -1 }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/GameController.cs
+++ b/Assets/Scripts/Runtime/GameController.cs
@@ -64,11 +64,19 @@ public class GameController : MonoBehaviour
         Notify();
     }
 
-    public (bool success, string text) ResolveEvent(string eventId, string optionId)
+    public (bool success, string text) ResolveEvent(string nodeId, string eventId, string optionId)
     {
-        var res = Sim.ResolveEvent(State, eventId, optionId, _rng);
+        var res = Sim.ResolveEvent(State, nodeId, eventId, optionId, _rng);
         Notify();
         return res;
+    }
+
+    // Legacy wrapper: locate node by eventId across all nodes.
+    public (bool success, string text) ResolveEvent(string eventId, string optionId)
+    {
+        var node = State.Nodes.FirstOrDefault(n => n?.PendingEvents != null && n.PendingEvents.Any(e => e != null && e.EventId == eventId));
+        if (node == null) return (false, "事件不存在");
+        return ResolveEvent(node.Id, eventId, optionId);
     }
 
     // =====================

--- a/Assets/Scripts/UI/HUD.cs
+++ b/Assets/Scripts/UI/HUD.cs
@@ -108,7 +108,12 @@ public class HUD : MonoBehaviour
 
         if (debugText)
         {
-            int ev = (s.PendingEvents != null) ? s.PendingEvents.Count : 0;
+            int ev = 0;
+            if (s.Nodes != null)
+            {
+                foreach (var node in s.Nodes)
+                    ev += node?.PendingEvents?.Count ?? 0;
+            }
             debugText.text = $"Events: {ev}";
         }
 

--- a/Assets/Scripts/UI/NodeButton.cs
+++ b/Assets/Scripts/UI/NodeButton.cs
@@ -110,6 +110,12 @@ public class NodeButton : MonoBehaviour
             }
         }
 
+        int pendingEvents = node.PendingEvents != null ? node.PendingEvents.Count : 0;
+        if (pendingEvents > 0)
+        {
+            sb.Append($"\n<color=#FFA500>E:{pendingEvents}</color>");
+        }
+
         if (label) label.text = sb.ToString();
     }
 }


### PR DESCRIPTION
### Motivation
- 以最小可控改动实现 P0‑4 事件系统 MVP，先用 stub 模板闭环，避免引入复杂的数据驱动以保证 Editor/WebGL 下稳定可跑通。 
- 把事件从全局列表移到节点上以支持节点级 `LocalPanic/Population` 效果与可序列化存档，并在现有日结/任务结算点触发事件。 

### Description
- 新增轻量事件数据模型和模板工厂：在 `Assets/Scripts/Core/NodeEvents.cs` 添加 `EventSource`, `EventInstance`, `EventOption`, `EventEffect`, 以及 `EventTemplates`（6 类来源每类至少一个模板，生成实例时创建唯一 `EventId`）。
- 节点挂载与本地状态：在 `Assets/Scripts/Core/GameState.cs` 的 `NodeState` 中新增 `LocalPanic`, `Population`, `PendingEvents : List<EventInstance>`，保持序列化风格一致。 
- 事件生成与结算接入点：在 `Assets/Scripts/Core/Sim.cs` 中接入六类来源：`Fixed`（固定日触发）、`Investigate`/`Contain`（在 `CompleteTask` 时触发）、`SecuredManage`（管理产出时触发）、`LocalPanicHigh` 与 `Random`（在 `StepDay` 过天时按阈值/高概率触发），并实现 `TryGenerateEvent`, `ResolveEvent(nodeId, eventId, optionId)`, `ApplyIgnorePenaltyOnDayEnd` 与三类调试日志。 
- UI 入口与展示：`EventPanel` 改为接收 `EventInstance` 并动态生成选项并调用 `GameController.ResolveEvent(nodeId,eventId,optionId)`；`UIPanelRoot` 新增 `OpenNodeEvent(nodeId)` 并改进自动弹窗逻辑；`NodePanelView`/`NodeButton` 显示事件数量并提供“处理事件”按钮（以 `E:{count}` 或 prefab 的 `EventCountText`/`Btn_ProcessEvent` 为适配点）。
- Controller 兼容：在 `Assets/Scripts/Runtime/GameController.cs` 新增新的 `ResolveEvent(nodeId,eventId,optionId)` 签名并保留一个 legacy wrapper 以兼容旧调用。 

### Testing
- 执行静态符号搜索以确认连线：运行匹配如 `rg "EventSource|EventInstance|OpenNodeEvent|ApplyIgnorePenaltyOnDayEnd" Assets/Scripts -S` 并验证这些符号出现在预期文件中（通过）。
- 运行代码 diff/whitespace 检查以确认没有明显格式/冲突问题（无错误返回）。
- 程序化检查已修改/新增文件清单以确认交付物完整并且代码位置与 UI 钩子一致（文件列表与变更已验证）；未在此 PR 中执行 Unity 编辑器或 WebGL 二进制运行，但所有变更均为小面向后端/UI 绑定的增量实现以降低回归风险。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697480c7d9fc8322815e63b78a8b5513)