### PR TITLE
Fix Random ambiguity in Core/Sim

### DIFF
--- a/Assets/Scripts/Core/Sim.cs
+++ b/Assets/Scripts/Core/Sim.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using Random = System.Random;
 
 namespace Core
 {


### PR DESCRIPTION
### Motivation
- Resolve CS0104 compiler errors caused by an ambiguous `Random` reference between `UnityEngine.Random` and `System.Random` in the simulation core.

### Description
- Add `using Random = System.Random;` to `Assets/Scripts/Core/Sim.cs` so all `Random` parameters/usages in the file unambiguously refer to `System.Random`.

### Testing
- Ran `rg "\bRandom\b" Assets/Scripts/Core/Sim.cs` to confirm the alias is present and usages remain intact (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697483241c3483229feceba1230671d4)