### PR TITLE
Refactor EventPanel to spawn option buttons and suppress auto-open chaining

### DIFF
--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -44,6 +44,7 @@ public class UIPanelRoot : MonoBehaviour
     private string _currentNodeId;
     private string _manageNodeId; // 当前打开的管理面板所对应的节点（与 NodePanel 的当前节点解耦）
     private string _pickerTaskId;
+    private bool _suppressAutoOpenEvent;
 
     public string CurrentNodeId => _currentNodeId;
     public string ManageNodeId => _manageNodeId;
@@ -313,11 +314,18 @@ public class UIPanelRoot : MonoBehaviour
 
         _eventPanel.gameObject.SetActive(true);
         _eventPanel.transform.SetAsLastSibling();
-        _eventPanel.Show(node.PendingEvents[0]);
+        _suppressAutoOpenEvent = true;
+        var ev = node.PendingEvents[0];
+        _eventPanel.Show(ev, optionId =>
+        {
+            _suppressAutoOpenEvent = true;
+            GameController.I.ResolveEvent(ev.NodeId, ev.EventId, optionId);
+        });
     }
 
     void TryAutoOpenEvent()
     {
+        if (_suppressAutoOpenEvent) return;
         // If a higher priority panel is shown, do not open events
         if (_agentPicker && _agentPicker.IsShown) return;
         if (GameController.I == null || GameController.I.State?.Nodes == null) return;
@@ -331,7 +339,11 @@ public class UIPanelRoot : MonoBehaviour
         {
             _eventPanel.gameObject.SetActive(true);
             _eventPanel.transform.SetAsLastSibling();
-            _eventPanel.Show(ev);
+            _eventPanel.Show(ev, optionId =>
+            {
+                _suppressAutoOpenEvent = true;
+                GameController.I.ResolveEvent(ev.NodeId, ev.EventId, optionId);
+            });
         }
     }
 


### PR DESCRIPTION
### Motivation

- Replace the old two-button hardcoded event UI with a minimal, generic option renderer that instantiates an inactive template for each option and exposes a simple `Show(ev, onChoose, onClose)` API.
- Prevent automatic re-opening of the next pending event immediately after resolving one to avoid automatic chaining/popups.

### Description

- Replace old serialized fields with the minimal set: `TMP_Text titleText`, `TMP_Text descText`, `Transform optionsRoot`, `Button optionButtonTemplate`, `Button closeButton`, and implement `Show(EventInstance ev, Action<string> onChoose, Action onClose = null)` and `Hide()` in `Assets/Scripts/UI/EventPanel.cs`.
- Render options by clearing child objects under `optionsRoot` (preserving the template), instantiating `optionButtonTemplate` per `ev.Options`, calling `RemoveAllListeners()` then binding click to call `onChoose(optionId)` and `Hide()`, and set the template inactive on `Show`.
- Add logs: `"[EventUI] Show node=.. eventId=.. options=N pendingCount=.."` and `"[EventUI] Click option=.. node=.. eventId=.."`.
- Move event resolution responsibility into `UIPanelRoot` by passing an `onChoose` callback when calling `EventPanel.Show`, and add a minimal gate `_suppressAutoOpenEvent` in `Assets/Scripts/UI/UIPanelRoot.cs` to avoid immediate auto-open after manual open/resolve.
- Prefab binding suggestions (based on current `Assets/Prefabs/UI/EventPanel.prefab`): `TitleText` → `EventPanel/Window/TitleText`, `DescText` → `EventPanel/Desc`, `OptionsRoot` → `EventPanel/Options`, `OptionButtonTemplate` → `EventPanel/Options/OptionButtonTemplate` (add and make inactive), `CloseButton` → `EventPanel/Window/CloseButton`.

### Testing

- Ran `git diff --check` to validate diffs and found no issues (passed).
- Ran `git status --porcelain` to confirm working tree state (passed).
- Changes committed with message `Refactor event panel option rendering and gate auto-open` (commit succeeded).

No automated unit tests were added; no playmode/build was executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69748707dc388322bd6057360f72f83a)