### PR TITLE
Add Event UI show/open diagnostic logs

### DIFF
--- a/Assets/Scripts/UI/EventPanel.cs
+++ b/Assets/Scripts/UI/EventPanel.cs
@@ -23,6 +23,8 @@ public class EventPanel : MonoBehaviour
     {
         if (ev == null) return;
 
+        Debug.Log($"[EventUI] Show node={ev.NodeId} eventId={ev.EventId} titleLen={ev.Title?.Length} descLen={ev.Desc?.Length} options={ev.Options?.Count}");
+
         _eventInstance = ev;
         _onChoose = onChoose;
         _onClose = onClose;

--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -315,7 +315,9 @@ public class UIPanelRoot : MonoBehaviour
         _eventPanel.gameObject.SetActive(true);
         _eventPanel.transform.SetAsLastSibling();
         _suppressAutoOpenEvent = true;
+        int pendingCount = node.PendingEvents.Count;
         var ev = node.PendingEvents[0];
+        Debug.Log($"[EventUI] Open node={nodeId} pending={pendingCount} eventId={ev?.EventId}");
         _eventPanel.Show(ev, optionId =>
         {
             _suppressAutoOpenEvent = true;


### PR DESCRIPTION
### Motivation
- Add stronger diagnostic logging to the event UI to help investigate when events are shown or opened and to surface event metadata for debugging.

### Description
- Inserted a `Debug.Log` at the start of `EventPanel.Show(...)` that prints `nodeId`, `eventId`, `titleLen`, `descLen`, and `options` count, and added a `Debug.Log` in `UIPanelRoot.OpenNodeEvent(...)` that reports `nodeId`, `pendingCount`, and the first `eventId`.

### Testing
- Attempted to run `dotnet build` to compile the project but it failed in the container because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697489dd0160832287822ced5cd11231)