### PR TITLE
Disable auto event popup and add pending-event attention flag

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -117,6 +117,7 @@ namespace Core
         public int LocalPanic = 0;
         public int Population = 10;
         public List<EventInstance> PendingEvents = new();
+        public bool HasPendingEvent => PendingEvents != null && PendingEvents.Count > 0;
 
         // ===== Legacy fields (temporary) =====
         // Kept so existing UI/code can compile during migration. Do not use for new features.

--- a/Assets/Scripts/UI/NodeButton.cs
+++ b/Assets/Scripts/UI/NodeButton.cs
@@ -110,7 +110,7 @@ public class NodeButton : MonoBehaviour
             }
         }
 
-        int pendingEvents = node.PendingEvents != null ? node.PendingEvents.Count : 0;
+        int pendingEvents = node.HasPendingEvent ? node.PendingEvents.Count : 0;
         if (pendingEvents > 0)
         {
             sb.Append($"\n<color=#FFA500>E:{pendingEvents}</color>");

--- a/Assets/Scripts/UI/NodePanelView.cs
+++ b/Assets/Scripts/UI/NodePanelView.cs
@@ -194,12 +194,13 @@ public class NodePanelView : MonoBehaviour
 
         string s = $"{n.Status}";
         if (n.HasAnomaly) s += " <color=red>[ANOMALY]</color>";
+        if (n.HasPendingEvent) s += " <color=#FFA500>[ATTENTION]</color>";
         if (statusText) statusText.text = s;
 
         UpdateDispatchButtons(n);
         UpdateManageButton(n);
 
-        int pendingEvents = n.PendingEvents != null ? n.PendingEvents.Count : 0;
+        int pendingEvents = n.HasPendingEvent ? n.PendingEvents.Count : 0;
 
         if (eventCountText)
         {

--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -324,17 +324,8 @@ public class UIPanelRoot : MonoBehaviour
 
     void TryAutoOpenEvent()
     {
-        if (_suppressAutoOpenEvent) return;
-        // If a higher priority panel is shown, do not open events
-        if (_agentPicker && _agentPicker.IsShown) return;
-        if (GameController.I == null || GameController.I.State?.Nodes == null) return;
-
-        if (!TryGetFirstPendingEvent(out var foundNodeId, out _)) return;
-
-        if (!_eventPanel || !_eventPanel.gameObject.activeSelf)
-        {
-            OpenNodeEvent(foundNodeId);
-        }
+        // Auto-open is disabled. Events should only be opened via manual entry points.
+        return;
     }
 
     private bool TryGetFirstPendingEvent(out string nodeId, out EventInstance ev)


### PR DESCRIPTION
### Motivation
- 禁止事件面板在状态变更时自动弹出，改为只通过手动入口处理事件以避免意外中断用户操作。 
- 避免把事件待处理状态写入节点核心 `Status`，提供单独的只读提示属性用于 UI 展示。

### Description
- 将 `TryAutoOpenEvent()` 直接 `return;`，彻底禁用自动弹出逻辑（文件：`Assets/Scripts/UI/UIPanelRoot.cs`）。
- 在节点状态中新增计算属性 `HasPendingEvent`，以 `PendingEvents` 列表为依据提供布尔提示（文件：`Assets/Scripts/Core/GameState.cs`）。
- 将 `NodePanelView` 与 `NodeButton` 改为基于 `HasPendingEvent` 显示事件计数，并在面板状态中添加 ` [ATTENTION]` 标记以提示用户（文件：`Assets/Scripts/UI/NodePanelView.cs`、`Assets/Scripts/UI/NodeButton.cs`）。
- 保留并使用手动入口：`NodePanelView` 的“处理事件”按钮仍然调用 `UIPanelRoot.OpenNodeEvent(nodeId)`，且 `OpenNodeEvent` 仍只处理 `PendingEvents[0]`（不循环、不连跳）。

### Testing
- 尝试运行 `dotnet build` 以编译项目，但在此环境中 `dotnet` 未安装导致构建失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974901602988322ad3c0afbad027525)