### PR TITLE
Route NodeButton clicks to OpenNodeEvent when pending events exist

### DIFF
--- a/Assets/Scripts/UI/NodeButton.cs
+++ b/Assets/Scripts/UI/NodeButton.cs
@@ -25,7 +25,14 @@ public class NodeButton : MonoBehaviour
 
     void OnClick()
     {
-        if (UIPanelRoot.I) UIPanelRoot.I.OpenNode(NodeId);
+        if (UIPanelRoot.I == null || GameController.I == null || string.IsNullOrEmpty(NodeId))
+            return;
+
+        var node = GameController.I.GetNode(NodeId);
+        if (node != null && node.PendingEvents != null && node.PendingEvents.Count > 0)
+            UIPanelRoot.I.OpenNodeEvent(NodeId);
+        else
+            UIPanelRoot.I.OpenNode(NodeId);
     }
 
     public void Set(string nodeId, string _unusedText)


### PR DESCRIPTION
### Motivation
- Ensure clicking a map node opens the node event panel when the node has pending events and avoid null-reference calls when UI root, controller, or node id are missing.

### Description
- Update `NodeButton.OnClick` to early-return if `UIPanelRoot.I`, `GameController.I`, or `NodeId` are null or empty.
- Resolve the node via `GameController.I.GetNode(NodeId)` and call `UIPanelRoot.I.OpenNodeEvent(NodeId)` when `node.PendingEvents.Count > 0`.
- Fall back to calling `UIPanelRoot.I.OpenNode(NodeId)` when there are no pending events.
- Add a null check for `node.PendingEvents` to avoid potential null dereference.

### Testing
- Ran `git diff --check` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749817715483229e5d98daf3285a5a)