### PR TITLE
Unify map node refresh on EndDay, ResolveEvent and ignore-penalty

### DIFF
--- a/Assets/Scripts/Core/Sim.cs
+++ b/Assets/Scripts/Core/Sim.cs
@@ -21,6 +21,8 @@ namespace Core
         private const int FIXED_EVENT_DAY = 3;
         private const string FIXED_EVENT_NODE_ID = "N1";
 
+        public static event Action OnIgnorePenaltyApplied;
+
         public static void StepDay(GameState s, Random rng)
         {
             s.Day += 1;
@@ -184,8 +186,9 @@ namespace Core
             return true;
         }
 
-        public static void ApplyIgnorePenaltyOnDayEnd(GameState s)
+        public static bool ApplyIgnorePenaltyOnDayEnd(GameState s)
         {
+            bool anyApplied = false;
             foreach (var node in s.Nodes)
             {
                 if (!HasPendingNodeEvents(node)) continue;
@@ -194,9 +197,13 @@ namespace Core
                 {
                     if (ev == null || ev.IgnorePenalty == null) continue;
                     ApplyEffect(s, node, ev.IgnorePenalty);
+                    anyApplied = true;
                     Debug.Log($"[EventIgnore] day={s.Day} node={node.Id} eventId={ev.EventId} penalty={ev.IgnorePenalty} localPanic={node.LocalPanic} pop={node.Population}");
                 }
             }
+
+            if (anyApplied) OnIgnorePenaltyApplied?.Invoke();
+            return anyApplied;
         }
 
         private static bool HasPendingNodeEvents(NodeState node)

--- a/Assets/Scripts/UI/MapNodeSpawner.cs
+++ b/Assets/Scripts/UI/MapNodeSpawner.cs
@@ -3,9 +3,16 @@ using UnityEngine;
 
 public class MapNodeSpawner : MonoBehaviour
 {
+    public static MapNodeSpawner I { get; private set; }
+
     [SerializeField] private RectTransform mapRect;      // MapImage 的 RectTransform
     [SerializeField] private RectTransform nodeLayer;    // NodeLayer
     [SerializeField] private NodeButton nodePrefab;
+
+    private void Awake()
+    {
+        I = this;
+    }
 
     private void Start()
     {
@@ -30,8 +37,13 @@ public class MapNodeSpawner : MonoBehaviour
         }
     }
 
+    public void RefreshMapNodes()
+    {
+        Build();
+    }
+
     private void Refresh()
     {
-        // 以后你可以根据状态改颜色/图标，这里先不做
+        RefreshMapNodes();
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the map UI updates consistently after day-end processing, after resolving an event, and after automatic ignore-penalty application so map nodes and the node panel reflect the latest state.

### Description
- Add `Sim.OnIgnorePenaltyApplied` and make `ApplyIgnorePenaltyOnDayEnd` return `bool` and invoke the event when any ignore penalty is applied.
- Centralize refresh logic in `GameController.RefreshMapNodes()` which calls `MapNodeSpawner.I?.RefreshMapNodes()` and `UIPanelRoot.I?.RefreshNodePanel()` and subscribe `GameController` to `Sim.OnIgnorePenaltyApplied` (with safe unsubscribe in `OnDestroy`).
- Trigger `RefreshMapNodes()` after `GameController.EndDay()` and after `GameController.ResolveEvent(...)` to cover day-end and manual event resolution flows.
- Expose `MapNodeSpawner.I` singleton, add `RefreshMapNodes()` (calls existing `Build()`), and wire existing `Refresh()` to `RefreshMapNodes()` so external callers can request a map rebuild.

### Testing
- Attempted to run `dotnet build SCP.slnx` in this environment but `dotnet` is not installed, so build could not be executed here (failure).
- Verified changes via local repository commands (`git diff`, `git status`) and committed the patch successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974993edbb0832280c3e3d1d77f0c41)