### PR TITLE
Remove committed XLSX sample from StreamingAssets

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -38,6 +38,7 @@ namespace Core
         public string Id;
         public string Name;
         public int Level = 1;
+        public string AnomalyId;
     }
 
     // 收容后进入“已收藏异常”，可被分配干员进行长期管理，按天产出负熵。
@@ -47,6 +48,8 @@ namespace Core
         public string Id;
         public string Name;
         public int Level = 1;
+        public string AnomalyId;
+        public string AnomalyClass;
 
         // 左侧“已收藏异常”列表使用（后续可做收藏/取消收藏筛选）
         public bool Favorited = true;
@@ -93,6 +96,7 @@ namespace Core
     {
         public string Id;
         public string Name;
+        public List<string> Tags = new();
 
         // 0..1 百分比坐标：左下(0,0) 右上(1,1)
         public float X;
@@ -103,6 +107,7 @@ namespace Core
 
         public bool HasAnomaly = false;
         public int AnomalyLevel = 0;
+        public List<string> ActiveAnomalyIds = new();
 
         // 调查产出：可收容目标列表（调查完成后写入）
         public List<ContainableItem> Containables = new();

--- a/Assets/Scripts/Core/NodeEvents.cs
+++ b/Assets/Scripts/Core/NodeEvents.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using Data;
 
 namespace Core
 {
@@ -8,275 +8,42 @@ namespace Core
     {
         Investigate,
         Contain,
+        Manage,
         LocalPanicHigh,
         Fixed,
         SecuredManage,
-        Random
-    }
-
-    [Serializable]
-    public class EventEffect
-    {
-        public int LocalPanicDelta = 0;
-        public int PopulationDelta = 0;
-        public int GlobalPanicDelta = 0;
-        public int MoneyDelta = 0;
-        public int NegEntropyDelta = 0;
-
-        public override string ToString()
-        {
-            return $"LocalPanicDelta={LocalPanicDelta},PopulationDelta={PopulationDelta},GlobalPanicDelta={GlobalPanicDelta},MoneyDelta={MoneyDelta},NegEntropyDelta={NegEntropyDelta}";
-        }
-    }
-
-    [Serializable]
-    public class EventOption
-    {
-        public string OptionId;
-        public string Text;
-        public string ResultText;
-        public EventEffect Effects = new EventEffect();
+        Random,
     }
 
     [Serializable]
     public class EventInstance
     {
-        public string EventId;
-        public EventSource Source;
+        public string EventInstanceId;
+        public string EventDefId;
         public string NodeId;
-        public string Title;
-        public string Desc;
-        public List<EventOption> Options = new();
         public int CreatedDay;
-        public EventEffect IgnorePenalty = new EventEffect();
+        public CauseType CauseType;
+        public string SourceTaskId;
+        public string SourceAnomalyId;
+
+        // Runtime metadata for ignore-apply policies.
+        public bool IgnoreAppliedOnce;
     }
 
-    [Serializable]
-    public class EventTemplate
+    public static class EventInstanceFactory
     {
-        public EventSource Source;
-        public string Title;
-        public string Desc;
-        public List<EventOption> Options = new();
-        public EventEffect IgnorePenalty = new EventEffect();
-    }
-
-    public static class EventTemplates
-    {
-        private static readonly List<EventTemplate> Templates = new()
+        public static EventInstance Create(string eventDefId, string nodeId, int day, CauseType causeType, string sourceTaskId = null, string sourceAnomalyId = null)
         {
-            BuildInvestigate(),
-            BuildContain(),
-            BuildLocalPanicHigh(),
-            BuildFixed(),
-            BuildSecuredManage(),
-            BuildRandom(),
-        };
-
-        public static EventInstance CreateInstance(EventSource source, string nodeId, int day, Random rng)
-        {
-            var template = PickTemplate(source, rng);
-            if (template == null) return null;
-
             return new EventInstance
             {
-                EventId = $"EV_{Guid.NewGuid().ToString("N")[..8]}",
-                Source = source,
+                EventInstanceId = $"EVI_{Guid.NewGuid():N}",
+                EventDefId = eventDefId,
                 NodeId = nodeId,
-                Title = template.Title,
-                Desc = template.Desc,
-                Options = template.Options.Select(CloneOption).ToList(),
                 CreatedDay = day,
-                IgnorePenalty = CloneEffect(template.IgnorePenalty)
-            };
-        }
-
-        private static EventTemplate PickTemplate(EventSource source, Random rng)
-        {
-            var candidates = Templates.Where(t => t != null && t.Source == source).ToList();
-            if (candidates.Count == 0) return null;
-            if (rng == null || candidates.Count == 1) return candidates[0];
-            return candidates[rng.Next(candidates.Count)];
-        }
-
-        private static EventOption CloneOption(EventOption opt)
-        {
-            if (opt == null) return null;
-            return new EventOption
-            {
-                OptionId = opt.OptionId,
-                Text = opt.Text,
-                ResultText = opt.ResultText,
-                Effects = CloneEffect(opt.Effects)
-            };
-        }
-
-        private static EventEffect CloneEffect(EventEffect eff)
-        {
-            if (eff == null) return new EventEffect();
-            return new EventEffect
-            {
-                LocalPanicDelta = eff.LocalPanicDelta,
-                PopulationDelta = eff.PopulationDelta,
-                GlobalPanicDelta = eff.GlobalPanicDelta,
-                MoneyDelta = eff.MoneyDelta,
-                NegEntropyDelta = eff.NegEntropyDelta
-            };
-        }
-
-        private static EventTemplate BuildInvestigate()
-        {
-            return new EventTemplate
-            {
-                Source = EventSource.Investigate,
-                Title = "调查引发关注",
-                Desc = "调查行动被目击，媒体开始追问。",
-                IgnorePenalty = new EventEffect { LocalPanicDelta = 2, PopulationDelta = -1 },
-                Options = new List<EventOption>
-                {
-                    new EventOption
-                    {
-                        OptionId = "INV_CALM",
-                        Text = "低调安抚目击者",
-                        Effects = new EventEffect { LocalPanicDelta = -1, PopulationDelta = 0 }
-                    },
-                    new EventOption
-                    {
-                        OptionId = "INV_FORCE",
-                        Text = "强硬封锁消息",
-                        Effects = new EventEffect { LocalPanicDelta = -2, PopulationDelta = -1, GlobalPanicDelta = 1 }
-                    }
-                }
-            };
-        }
-
-        private static EventTemplate BuildContain()
-        {
-            return new EventTemplate
-            {
-                Source = EventSource.Contain,
-                Title = "收容现场余波",
-                Desc = "收容过程造成附带损失，需要后续处理。",
-                IgnorePenalty = new EventEffect { LocalPanicDelta = 2, PopulationDelta = -1 },
-                Options = new List<EventOption>
-                {
-                    new EventOption
-                    {
-                        OptionId = "CON_REPAIR",
-                        Text = "优先修复与善后",
-                        Effects = new EventEffect { LocalPanicDelta = -1, MoneyDelta = -50 }
-                    },
-                    new EventOption
-                    {
-                        OptionId = "CON_PUSH",
-                        Text = "压下损失继续推进",
-                        Effects = new EventEffect { LocalPanicDelta = 1, PopulationDelta = -1, MoneyDelta = 50 }
-                    }
-                }
-            };
-        }
-
-        private static EventTemplate BuildLocalPanicHigh()
-        {
-            return new EventTemplate
-            {
-                Source = EventSource.LocalPanicHigh,
-                Title = "本地恐慌蔓延",
-                Desc = "恐慌已接近失控，社区秩序开始崩坏。",
-                IgnorePenalty = new EventEffect { LocalPanicDelta = 3, PopulationDelta = -1, GlobalPanicDelta = 1 },
-                Options = new List<EventOption>
-                {
-                    new EventOption
-                    {
-                        OptionId = "LP_PUBLIC",
-                        Text = "公开安抚与物资投放",
-                        Effects = new EventEffect { LocalPanicDelta = -2, MoneyDelta = -80 }
-                    },
-                    new EventOption
-                    {
-                        OptionId = "LP_LOCKDOWN",
-                        Text = "强制管制区域",
-                        Effects = new EventEffect { LocalPanicDelta = -1, PopulationDelta = -1 }
-                    }
-                }
-            };
-        }
-
-        private static EventTemplate BuildFixed()
-        {
-            return new EventTemplate
-            {
-                Source = EventSource.Fixed,
-                Title = "预定演习事故",
-                Desc = "例行演习中发生误报，公众开始质疑机构能力。",
-                IgnorePenalty = new EventEffect { LocalPanicDelta = 2, GlobalPanicDelta = 1 },
-                Options = new List<EventOption>
-                {
-                    new EventOption
-                    {
-                        OptionId = "FX_APOLOGY",
-                        Text = "发布正式说明",
-                        Effects = new EventEffect { LocalPanicDelta = -1, MoneyDelta = -30 }
-                    },
-                    new EventOption
-                    {
-                        OptionId = "FX_SPIN",
-                        Text = "转移舆论焦点",
-                        Effects = new EventEffect { LocalPanicDelta = 0, GlobalPanicDelta = 1, MoneyDelta = 30 }
-                    }
-                }
-            };
-        }
-
-        private static EventTemplate BuildSecuredManage()
-        {
-            return new EventTemplate
-            {
-                Source = EventSource.SecuredManage,
-                Title = "管理流程审计",
-                Desc = "已收容异常的管理流程被抽查，需要即时回应。",
-                IgnorePenalty = new EventEffect { LocalPanicDelta = 1, NegEntropyDelta = -1 },
-                Options = new List<EventOption>
-                {
-                    new EventOption
-                    {
-                        OptionId = "SM_COMPLY",
-                        Text = "全面配合审计",
-                        Effects = new EventEffect { LocalPanicDelta = -1, NegEntropyDelta = -1 }
-                    },
-                    new EventOption
-                    {
-                        OptionId = "SM_HIDE",
-                        Text = "压缩审计范围",
-                        Effects = new EventEffect { LocalPanicDelta = 1, NegEntropyDelta = 1 }
-                    }
-                }
-            };
-        }
-
-        private static EventTemplate BuildRandom()
-        {
-            return new EventTemplate
-            {
-                Source = EventSource.Random,
-                Title = "偶发目击报告",
-                Desc = "匿名举报称发现异常活动，需要选择响应策略。",
-                IgnorePenalty = new EventEffect { LocalPanicDelta = 1 },
-                Options = new List<EventOption>
-                {
-                    new EventOption
-                    {
-                        OptionId = "RD_VERIFY",
-                        Text = "谨慎核查",
-                        Effects = new EventEffect { LocalPanicDelta = -1, MoneyDelta = -20 }
-                    },
-                    new EventOption
-                    {
-                        OptionId = "RD_SWEEP",
-                        Text = "快速清场",
-                        Effects = new EventEffect { LocalPanicDelta = 1, PopulationDelta = -1 }
-                    }
-                }
+                CauseType = causeType,
+                SourceTaskId = sourceTaskId,
+                SourceAnomalyId = sourceAnomalyId,
+                IgnoreAppliedOnce = false,
             };
         }
     }

--- a/Assets/Scripts/Data/DataRegistry.cs
+++ b/Assets/Scripts/Data/DataRegistry.cs
@@ -1,0 +1,512 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Core;
+using UnityEngine;
+
+namespace Data
+{
+    public enum CauseType
+    {
+        TaskInvestigate,
+        TaskContain,
+        TaskManage,
+        Anomaly,
+        LocalPanic,
+        Fixed,
+        Random,
+    }
+
+    public enum BlockPolicy
+    {
+        None,
+        BlockOriginTask,
+        BlockAllTasksOnNode,
+    }
+
+    public enum IgnoreApplyMode
+    {
+        ApplyOnceThenRemove,
+        ApplyDailyKeep,
+        NeverAuto,
+    }
+
+    public enum AffectScopeKind
+    {
+        OriginTask,
+        Node,
+        Global,
+        TaskType,
+    }
+
+    public enum EffectOpType
+    {
+        Add,
+        Mul,
+        Set,
+        ClampAdd,
+    }
+
+    public readonly struct AffectScope
+    {
+        public AffectScope(AffectScopeKind kind, TaskType? taskType = null)
+        {
+            Kind = kind;
+            TaskType = taskType;
+        }
+
+        public AffectScopeKind Kind { get; }
+        public TaskType? TaskType { get; }
+        public string Raw => Kind == AffectScopeKind.TaskType && TaskType.HasValue ? $"TaskType:{TaskType.Value}" : Kind.ToString();
+
+        public override string ToString() => Raw;
+    }
+
+    public sealed class EffectOp
+    {
+        public string EffectId;
+        public AffectScope Scope;
+        public string StatKey;
+        public EffectOpType Op;
+        public float Value;
+        public float? Min;
+        public float? Max;
+        public string Comment;
+    }
+
+    public sealed class EventTrigger
+    {
+        public string EventDefId;
+        public int? MinDay;
+        public int? MaxDay;
+        public List<string> RequiresNodeTagsAny = new();
+        public List<string> RequiresNodeTagsAll = new();
+        public List<string> RequiresAnomalyTagsAny = new();
+        public bool? RequiresSecured;
+        public int? MinLocalPanic;
+        public TaskType? TaskType;
+        public bool? OnlyAffectOriginTask;
+    }
+
+    public sealed class DataRegistry
+    {
+        private const string GameDataFileName = "game_data.json";
+
+        private static DataRegistry _instance;
+        public static DataRegistry Instance => _instance ??= LoadFromStreamingAssets();
+
+        public GameDataRoot Root { get; private set; }
+        public Dictionary<string, NodeDef> NodesById { get; private set; } = new();
+        public Dictionary<string, AnomalyDef> AnomaliesById { get; private set; } = new();
+        public Dictionary<TaskType, TaskDef> TaskDefsByType { get; private set; } = new();
+        public Dictionary<string, EventDef> EventsById { get; private set; } = new();
+        public Dictionary<string, List<EventOptionDef>> OptionsByEvent { get; private set; } = new();
+        public Dictionary<string, Dictionary<string, EventOptionDef>> OptionsByEventAndId { get; private set; } = new();
+        public Dictionary<string, EffectDef> EffectsById { get; private set; } = new();
+        public Dictionary<string, List<EffectOp>> EffectOpsByEffectId { get; private set; } = new();
+        public Dictionary<string, List<EventTrigger>> TriggersByEventId { get; private set; } = new();
+        public Dictionary<string, BalanceValue> Balance { get; private set; } = new();
+
+        public int LocalPanicHighThreshold { get; private set; } = 6;
+        public double RandomEventBaseProb { get; private set; } = 0.15d;
+        public int DefaultAutoResolveAfterDays { get; private set; } = 0;
+        public IgnoreApplyMode DefaultIgnoreApplyMode { get; private set; } = IgnoreApplyMode.ApplyDailyKeep;
+
+        private DataRegistry() { }
+
+        private static DataRegistry LoadFromStreamingAssets()
+        {
+            var registry = new DataRegistry();
+            registry.Reload();
+            return registry;
+        }
+
+        public void Reload()
+        {
+            string path = Path.Combine(Application.streamingAssetsPath, GameDataFileName);
+            if (!File.Exists(path))
+            {
+                Debug.LogError($"[DataRegistry] Missing game data at: {path}");
+                Root = new GameDataRoot();
+                return;
+            }
+
+            try
+            {
+                var json = File.ReadAllText(path);
+                var options = new JsonSerializerOptions
+                {
+                    IncludeFields = true,
+                    PropertyNameCaseInsensitive = true,
+                };
+                Root = JsonSerializer.Deserialize<GameDataRoot>(json, options) ?? new GameDataRoot();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[DataRegistry] Failed to load JSON: {ex}");
+                Root = new GameDataRoot();
+            }
+
+            BuildIndexes();
+            GameDataValidator.ValidateOrThrow(this);
+        }
+
+        private void BuildIndexes()
+        {
+            Balance = Root.balance ?? new Dictionary<string, BalanceValue>();
+
+            NodesById = (Root.nodes ?? new List<NodeDef>())
+                .Where(n => n != null && !string.IsNullOrEmpty(n.nodeId))
+                .ToDictionary(n => n.nodeId, n => n);
+
+            AnomaliesById = (Root.anomalies ?? new List<AnomalyDef>())
+                .Where(a => a != null && !string.IsNullOrEmpty(a.anomalyId))
+                .ToDictionary(a => a.anomalyId, a => a);
+
+            TaskDefsByType = new Dictionary<TaskType, TaskDef>();
+            foreach (var taskDef in Root.taskDefs ?? new List<TaskDef>())
+            {
+                if (taskDef == null) continue;
+                if (!TryParseTaskType(taskDef.taskType, out var type, out _)) continue;
+                TaskDefsByType[type] = taskDef;
+            }
+
+            EventsById = (Root.events ?? new List<EventDef>())
+                .Where(e => e != null && !string.IsNullOrEmpty(e.eventDefId))
+                .ToDictionary(e => e.eventDefId, e => e);
+
+            OptionsByEvent = new Dictionary<string, List<EventOptionDef>>();
+            OptionsByEventAndId = new Dictionary<string, Dictionary<string, EventOptionDef>>();
+            foreach (var option in Root.eventOptions ?? new List<EventOptionDef>())
+            {
+                if (option == null || string.IsNullOrEmpty(option.eventDefId) || string.IsNullOrEmpty(option.optionId)) continue;
+                if (!OptionsByEvent.TryGetValue(option.eventDefId, out var list))
+                {
+                    list = new List<EventOptionDef>();
+                    OptionsByEvent[option.eventDefId] = list;
+                }
+                list.Add(option);
+
+                if (!OptionsByEventAndId.TryGetValue(option.eventDefId, out var dict))
+                {
+                    dict = new Dictionary<string, EventOptionDef>();
+                    OptionsByEventAndId[option.eventDefId] = dict;
+                }
+                dict[option.optionId] = option;
+            }
+
+            EffectsById = (Root.effects ?? new List<EffectDef>())
+                .Where(e => e != null && !string.IsNullOrEmpty(e.effectId))
+                .ToDictionary(e => e.effectId, e => e);
+
+            EffectOpsByEffectId = new Dictionary<string, List<EffectOp>>();
+            foreach (var row in Root.effectOps ?? new List<EffectOpRow>())
+            {
+                if (row == null || string.IsNullOrEmpty(row.effectId)) continue;
+                if (!TryParseEffectOp(row, out var ops)) continue;
+
+                if (!EffectOpsByEffectId.TryGetValue(row.effectId, out var list))
+                {
+                    list = new List<EffectOp>();
+                    EffectOpsByEffectId[row.effectId] = list;
+                }
+                list.AddRange(ops);
+            }
+
+            TriggersByEventId = new Dictionary<string, List<EventTrigger>>();
+            foreach (var row in Root.eventTriggers ?? new List<EventTriggerRow>())
+            {
+                if (row == null || string.IsNullOrEmpty(row.eventDefId)) continue;
+                if (!TryParseTrigger(row, out var trigger)) continue;
+                if (!TriggersByEventId.TryGetValue(row.eventDefId, out var list))
+                {
+                    list = new List<EventTrigger>();
+                    TriggersByEventId[row.eventDefId] = list;
+                }
+                list.Add(trigger);
+            }
+
+            LocalPanicHighThreshold = GetBalanceInt("LocalPanicHighThreshold", LocalPanicHighThreshold);
+            RandomEventBaseProb = GetBalanceFloat("RandomEventBaseProb", (float)RandomEventBaseProb);
+            DefaultAutoResolveAfterDays = GetBalanceInt("DefaultAutoResolveAfterDays", DefaultAutoResolveAfterDays);
+
+            var defaultIgnoreApplyModeRaw = GetBalanceString("DefaultIgnoreApplyMode", DefaultIgnoreApplyMode.ToString());
+            if (TryParseIgnoreApplyMode(defaultIgnoreApplyModeRaw, out var parsedMode, out _))
+                DefaultIgnoreApplyMode = parsedMode;
+        }
+
+        private bool TryParseEffectOp(EffectOpRow row, out List<EffectOp> ops)
+        {
+            ops = new List<EffectOp>();
+            if (!TryParseEffectOpType(row.op, out var opType, out _)) return false;
+            if (!TryParseAffectScopes(row.scope, out var scopes, out _)) return false;
+
+            foreach (var scope in scopes)
+            {
+                ops.Add(new EffectOp
+                {
+                    EffectId = row.effectId,
+                    Scope = scope,
+                    StatKey = row.statKey,
+                    Op = opType,
+                    Value = row.value,
+                    Min = row.min,
+                    Max = row.max,
+                    Comment = row.comment,
+                });
+            }
+            return true;
+        }
+
+        private bool TryParseTrigger(EventTriggerRow row, out EventTrigger trigger)
+        {
+            trigger = new EventTrigger
+            {
+                EventDefId = row.eventDefId,
+                MinDay = row.minDay,
+                MaxDay = row.maxDay,
+                RequiresNodeTagsAny = row.requiresNodeTagsAny ?? new List<string>(),
+                RequiresNodeTagsAll = row.requiresNodeTagsAll ?? new List<string>(),
+                RequiresAnomalyTagsAny = row.requiresAnomalyTagsAny ?? new List<string>(),
+                RequiresSecured = row.requiresSecured,
+                MinLocalPanic = row.minLocalPanic,
+                OnlyAffectOriginTask = row.onlyAffectOriginTask,
+            };
+
+            if (!string.IsNullOrEmpty(row.taskType))
+            {
+                if (!TryParseTaskType(row.taskType, out var type, out _)) return false;
+                trigger.TaskType = type;
+            }
+
+            return true;
+        }
+
+        public bool TryGetEvent(string eventDefId, out EventDef def)
+            => EventsById.TryGetValue(eventDefId, out def);
+
+        public bool TryGetOption(string eventDefId, string optionId, out EventOptionDef option)
+        {
+            option = null;
+            if (!OptionsByEventAndId.TryGetValue(eventDefId, out var dict)) return false;
+            return dict.TryGetValue(optionId, out option);
+        }
+
+        public bool TryGetTaskDef(TaskType type, out TaskDef def)
+            => TaskDefsByType.TryGetValue(type, out def);
+
+        public int GetTaskBaseDays(TaskType type, int fallback)
+        {
+            return TryGetTaskDef(type, out var def) && def.baseDays > 0 ? def.baseDays : fallback;
+        }
+
+        public float GetTaskProgressPerDay(TaskType type, float fallback)
+        {
+            return TryGetTaskDef(type, out var def) && def.progressPerDay > 0f ? def.progressPerDay : fallback;
+        }
+
+        public IgnoreApplyMode GetIgnoreApplyMode(EventDef def)
+        {
+            if (def != null && TryParseIgnoreApplyMode(def.ignoreApplyMode, out var mode, out _))
+                return mode;
+            return DefaultIgnoreApplyMode;
+        }
+
+        public int GetAutoResolveAfterDays(EventDef def)
+        {
+            if (def != null && def.autoResolveAfterDays > 0) return def.autoResolveAfterDays;
+            return DefaultAutoResolveAfterDays;
+        }
+
+        private int GetBalanceInt(string key, int fallback)
+        {
+            if (!Balance.TryGetValue(key, out var val)) return fallback;
+            if (val == null || string.IsNullOrEmpty(val.value)) return fallback;
+            return int.TryParse(val.value, out var parsed) ? parsed : fallback;
+        }
+
+        private float GetBalanceFloat(string key, float fallback)
+        {
+            if (!Balance.TryGetValue(key, out var val)) return fallback;
+            if (val == null || string.IsNullOrEmpty(val.value)) return fallback;
+            return float.TryParse(val.value, out var parsed) ? parsed : fallback;
+        }
+
+        private string GetBalanceString(string key, string fallback)
+        {
+            if (!Balance.TryGetValue(key, out var val)) return fallback;
+            return string.IsNullOrEmpty(val?.value) ? fallback : val.value;
+        }
+
+        public static bool TryParseTaskType(string raw, out TaskType type, out string error)
+        {
+            error = null;
+            type = TaskType.Investigate;
+            if (string.IsNullOrEmpty(raw))
+            {
+                error = "TaskType empty";
+                return false;
+            }
+
+            if (Enum.TryParse(raw, true, out type)) return true;
+            error = $"Invalid TaskType: {raw}";
+            return false;
+        }
+
+        public static bool TryParseEventSource(string raw, out EventSource source, out string error)
+        {
+            error = null;
+            source = EventSource.Random;
+            if (string.IsNullOrEmpty(raw))
+            {
+                error = "EventSource empty";
+                return false;
+            }
+
+            if (Enum.TryParse(raw, true, out source)) return true;
+            error = $"Invalid EventSource: {raw}";
+            return false;
+        }
+
+        public static bool TryParseCauseType(string raw, out CauseType causeType, out string error)
+        {
+            error = null;
+            causeType = CauseType.Random;
+            if (string.IsNullOrEmpty(raw))
+            {
+                error = "CauseType empty";
+                return false;
+            }
+
+            if (Enum.TryParse(raw, true, out causeType)) return true;
+            error = $"Invalid CauseType: {raw}";
+            return false;
+        }
+
+        public static bool TryParseBlockPolicy(string raw, out BlockPolicy policy, out string error)
+        {
+            error = null;
+            policy = BlockPolicy.None;
+            if (string.IsNullOrEmpty(raw))
+            {
+                error = "BlockPolicy empty";
+                return false;
+            }
+
+            if (Enum.TryParse(raw, true, out policy)) return true;
+            error = $"Invalid BlockPolicy: {raw}";
+            return false;
+        }
+
+        public static bool TryParseIgnoreApplyMode(string raw, out IgnoreApplyMode mode, out string error)
+        {
+            error = null;
+            mode = IgnoreApplyMode.ApplyDailyKeep;
+            if (string.IsNullOrEmpty(raw))
+            {
+                error = "IgnoreApplyMode empty";
+                return false;
+            }
+
+            if (Enum.TryParse(raw, true, out mode)) return true;
+            error = $"Invalid IgnoreApplyMode: {raw}";
+            return false;
+        }
+
+        public static bool TryParseEffectOpType(string raw, out EffectOpType opType, out string error)
+        {
+            error = null;
+            opType = EffectOpType.Add;
+            if (string.IsNullOrEmpty(raw))
+            {
+                error = "EffectOpType empty";
+                return false;
+            }
+
+            if (Enum.TryParse(raw, true, out opType)) return true;
+            error = $"Invalid EffectOpType: {raw}";
+            return false;
+        }
+
+        public static bool TryParseAffectScopes(IEnumerable<string> raws, out List<AffectScope> scopes, out string error)
+        {
+            scopes = new List<AffectScope>();
+            error = null;
+            if (raws == null)
+            {
+                error = "AffectScope empty";
+                return false;
+            }
+
+            foreach (var raw in raws)
+            {
+                if (string.IsNullOrWhiteSpace(raw)) continue;
+                if (!TryParseAffectScope(raw, out var scope, out error)) return false;
+                scopes.Add(scope);
+            }
+
+            if (scopes.Count == 0)
+            {
+                error = "AffectScope empty";
+                return false;
+            }
+            return true;
+        }
+
+        public static bool TryParseAffectScopes(string raw, out List<AffectScope> scopes, out string error)
+        {
+            scopes = new List<AffectScope>();
+            error = null;
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                error = "AffectScope empty";
+                return false;
+            }
+
+            var parts = raw.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var part in parts)
+            {
+                if (!TryParseAffectScope(part.Trim(), out var scope, out error)) return false;
+                scopes.Add(scope);
+            }
+
+            if (scopes.Count == 0)
+            {
+                error = "AffectScope empty";
+                return false;
+            }
+
+            return true;
+        }
+
+        public static bool TryParseAffectScope(string raw, out AffectScope scope, out string error)
+        {
+            error = null;
+            scope = new AffectScope(AffectScopeKind.Node);
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                error = "AffectScope empty";
+                return false;
+            }
+
+            if (raw.StartsWith("TaskType:", StringComparison.OrdinalIgnoreCase))
+            {
+                var typeRaw = raw.Substring("TaskType:".Length);
+                if (!TryParseTaskType(typeRaw, out var taskType, out error)) return false;
+                scope = new AffectScope(AffectScopeKind.TaskType, taskType);
+                return true;
+            }
+
+            if (Enum.TryParse(raw, true, out AffectScopeKind kind))
+            {
+                scope = new AffectScope(kind);
+                return true;
+            }
+
+            error = $"Invalid AffectScope: {raw}";
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Data/EffectOpExecutor.cs
+++ b/Assets/Scripts/Data/EffectOpExecutor.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Core;
+using UnityEngine;
+
+namespace Data
+{
+    public sealed class EffectContext
+    {
+        public GameState State;
+        public NodeState Node;
+        public NodeTask OriginTask;
+        public string EventDefId;
+        public string OptionId;
+    }
+
+    public static class EffectOpExecutor
+    {
+        public static void ApplyEffect(string effectId, EffectContext ctx, IReadOnlyCollection<AffectScope> allowedScopes = null)
+        {
+            if (ctx?.State == null || string.IsNullOrEmpty(effectId)) return;
+
+            var registry = DataRegistry.Instance;
+            if (!registry.EffectOpsByEffectId.TryGetValue(effectId, out var ops) || ops == null || ops.Count == 0)
+            {
+                Debug.LogWarning($"[EffectOpExecutor] effectId={effectId} has no ops.");
+                return;
+            }
+
+            var allowedSet = allowedScopes != null && allowedScopes.Count > 0
+                ? new HashSet<string>(allowedScopes.Select(s => s.Raw))
+                : null;
+
+            foreach (var op in ops)
+            {
+                if (op == null) continue;
+                if (allowedSet != null && !allowedSet.Contains(op.Scope.Raw)) continue;
+                ApplyOp(op, ctx);
+            }
+        }
+
+        private static void ApplyOp(EffectOp op, EffectContext ctx)
+        {
+            switch (op.Scope.Kind)
+            {
+                case AffectScopeKind.Node:
+                    ApplyToNode(op, ctx.Node);
+                    break;
+                case AffectScopeKind.OriginTask:
+                    ApplyToTask(op, ctx.OriginTask);
+                    break;
+                case AffectScopeKind.Global:
+                    ApplyToGlobal(op, ctx.State);
+                    break;
+                case AffectScopeKind.TaskType:
+                    ApplyToTaskType(op, ctx.State, op.Scope.TaskType);
+                    break;
+                default:
+                    Debug.LogWarning($"[EffectOpExecutor] Unsupported scope {op.Scope}");
+                    break;
+            }
+        }
+
+        private static void ApplyToNode(EffectOp op, NodeState node)
+        {
+            if (node == null) return;
+
+            if (StatEquals(op.StatKey, "LocalPanic"))
+            {
+                node.LocalPanic = ApplyInt(node.LocalPanic, op, clampMin: 0);
+            }
+            else if (StatEquals(op.StatKey, "Population"))
+            {
+                node.Population = ApplyInt(node.Population, op, clampMin: 0);
+            }
+            else
+            {
+                Debug.LogWarning($"[EffectOpExecutor] Unknown node statKey={op.StatKey}");
+            }
+        }
+
+        private static void ApplyToTask(EffectOp op, NodeTask task)
+        {
+            if (task == null) return;
+            if (StatEquals(op.StatKey, "TaskProgressDelta"))
+            {
+                var value = ApplyFloat(task.Progress, op);
+                task.Progress = Mathf.Clamp01(value);
+                return;
+            }
+
+            Debug.LogWarning($"[EffectOpExecutor] Unknown task statKey={op.StatKey}");
+        }
+
+        private static void ApplyToGlobal(EffectOp op, GameState state)
+        {
+            if (state == null) return;
+
+            if (StatEquals(op.StatKey, "WorldPanic") || StatEquals(op.StatKey, "Panic"))
+            {
+                state.Panic = ApplyInt(state.Panic, op, clampMin: 0, clampMax: 100);
+            }
+            else if (StatEquals(op.StatKey, "Money"))
+            {
+                state.Money = ApplyInt(state.Money, op);
+            }
+            else if (StatEquals(op.StatKey, "NegEntropy"))
+            {
+                state.NegEntropy = ApplyInt(state.NegEntropy, op, clampMin: 0);
+            }
+            else
+            {
+                Debug.LogWarning($"[EffectOpExecutor] Unknown global statKey={op.StatKey}");
+            }
+        }
+
+        private static void ApplyToTaskType(EffectOp op, GameState state, TaskType? taskType)
+        {
+            if (state?.Nodes == null || !taskType.HasValue) return;
+            foreach (var node in state.Nodes)
+            {
+                if (node?.Tasks == null) continue;
+                foreach (var task in node.Tasks)
+                {
+                    if (task == null || task.State != TaskState.Active) continue;
+                    if (task.Type != taskType.Value) continue;
+                    ApplyToTask(op, task);
+                }
+            }
+        }
+
+        private static bool StatEquals(string statKey, string expected)
+            => string.Equals(statKey, expected, StringComparison.OrdinalIgnoreCase);
+
+        private static int ApplyInt(int current, EffectOp op, int? clampMin = null, int? clampMax = null)
+        {
+            var value = ApplyFloat(current, op);
+            var rounded = Mathf.RoundToInt(value);
+            if (clampMin.HasValue) rounded = Mathf.Max(clampMin.Value, rounded);
+            if (clampMax.HasValue) rounded = Mathf.Min(clampMax.Value, rounded);
+            return rounded;
+        }
+
+        private static float ApplyFloat(float current, EffectOp op)
+        {
+            float next = current;
+            switch (op.Op)
+            {
+                case EffectOpType.Add:
+                    next = current + op.Value;
+                    break;
+                case EffectOpType.Mul:
+                    next = current * op.Value;
+                    break;
+                case EffectOpType.Set:
+                    next = op.Value;
+                    break;
+                case EffectOpType.ClampAdd:
+                    next = current + op.Value;
+                    if (op.Min.HasValue) next = Mathf.Max(op.Min.Value, next);
+                    if (op.Max.HasValue) next = Mathf.Min(op.Max.Value, next);
+                    break;
+                default:
+                    Debug.LogWarning($"[EffectOpExecutor] Unsupported op {op.Op}");
+                    break;
+            }
+
+            if (op.Op != EffectOpType.ClampAdd)
+            {
+                if (op.Min.HasValue) next = Mathf.Max(op.Min.Value, next);
+                if (op.Max.HasValue) next = Mathf.Min(op.Max.Value, next);
+            }
+
+            return next;
+        }
+    }
+}

--- a/Assets/Scripts/Data/GameDataModels.cs
+++ b/Assets/Scripts/Data/GameDataModels.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+
+namespace Data
+{
+    [Serializable]
+    public class GameDataRoot
+    {
+        public MetaRow meta = new();
+        public Dictionary<string, BalanceValue> balance = new();
+        public List<NodeDef> nodes = new();
+        public List<AnomalyDef> anomalies = new();
+        public List<TaskDef> taskDefs = new();
+        public List<EventDef> events = new();
+        public List<EventOptionDef> eventOptions = new();
+        public List<EffectDef> effects = new();
+        public List<EffectOpRow> effectOps = new();
+        public List<EventTriggerRow> eventTriggers = new();
+    }
+
+    [Serializable]
+    public class MetaRow
+    {
+        public string schemaVersion;
+        public string dataVersion;
+        public string comment;
+    }
+
+    [Serializable]
+    public class BalanceValue
+    {
+        public string value;
+        public string type;
+        public string comment;
+    }
+
+    [Serializable]
+    public class NodeDef
+    {
+        public string nodeId;
+        public string name;
+        public List<string> tags = new();
+        public int startLocalPanic;
+        public int startPopulation;
+        public List<string> startAnomalyIds = new();
+    }
+
+    [Serializable]
+    public class AnomalyDef
+    {
+        public string anomalyId;
+        public string name;
+        public string @class;
+        public List<string> tags = new();
+        public int baseThreat;
+        public int investigateDifficulty;
+        public int containDifficulty;
+        public int manageRisk;
+    }
+
+    [Serializable]
+    public class TaskDef
+    {
+        public string taskDefId;
+        public string taskType;
+        public string name;
+        public int baseDays;
+        public float progressPerDay;
+        public int agentSlotsMin;
+        public int agentSlotsMax;
+        public string yieldKey;
+        public float yieldPerDay;
+    }
+
+    [Serializable]
+    public class EventDef
+    {
+        public string eventDefId;
+        public string source;
+        public string causeType;
+        public int weight;
+        public string title;
+        public string desc;
+        public string blockPolicy;
+        public List<string> defaultAffects = new();
+        public int autoResolveAfterDays;
+        public string ignoreApplyMode;
+        public string ignoreEffectId;
+    }
+
+    [Serializable]
+    public class EventOptionDef
+    {
+        public string eventDefId;
+        public string optionId;
+        public string text;
+        public string resultText;
+        public List<string> affects = new();
+        public string effectId;
+    }
+
+    [Serializable]
+    public class EffectDef
+    {
+        public string effectId;
+        public string comment;
+    }
+
+    [Serializable]
+    public class EffectOpRow
+    {
+        public string effectId;
+        public string scope;
+        public string statKey;
+        public string op;
+        public float value;
+        public float? min;
+        public float? max;
+        public string comment;
+    }
+
+    [Serializable]
+    public class EventTriggerRow
+    {
+        public string eventDefId;
+        public int? minDay;
+        public int? maxDay;
+        public List<string> requiresNodeTagsAny = new();
+        public List<string> requiresNodeTagsAll = new();
+        public List<string> requiresAnomalyTagsAny = new();
+        public bool? requiresSecured;
+        public int? minLocalPanic;
+        public string taskType;
+        public bool? onlyAffectOriginTask;
+    }
+}

--- a/Assets/Scripts/Data/GameDataValidator.cs
+++ b/Assets/Scripts/Data/GameDataValidator.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Core;
+using UnityEngine;
+
+namespace Data
+{
+    public static class GameDataValidator
+    {
+        public static void ValidateOrThrow(DataRegistry registry)
+        {
+            var errors = new List<string>();
+            if (registry == null)
+            {
+                throw new InvalidOperationException("[GameDataValidator] Registry is null.");
+            }
+
+            ValidateEnums(registry, errors);
+            ValidateForeignKeys(registry, errors);
+            ValidateTriggers(registry, errors);
+            ValidateBlockOriginTaskLogic(registry, errors);
+
+            if (errors.Count > 0)
+            {
+                var message = "[GameDataValidator] Validation failed:\n - " + string.Join("\n - ", errors);
+                Debug.LogError(message);
+                throw new InvalidOperationException(message);
+            }
+
+            Debug.Log($"[GameDataValidator] Validation passed. events={registry.EventsById.Count} effects={registry.EffectsById.Count}");
+        }
+
+        private static void ValidateEnums(DataRegistry registry, List<string> errors)
+        {
+            foreach (var ev in registry.Root.events ?? new List<EventDef>())
+            {
+                if (ev == null) continue;
+                if (!DataRegistry.TryParseEventSource(ev.source, out _, out var sourceError))
+                    errors.Add($"Events[{ev.eventDefId}].source: {sourceError}");
+                if (!DataRegistry.TryParseCauseType(ev.causeType, out _, out var causeError))
+                    errors.Add($"Events[{ev.eventDefId}].causeType: {causeError}");
+                if (!DataRegistry.TryParseBlockPolicy(ev.blockPolicy, out _, out var blockError))
+                    errors.Add($"Events[{ev.eventDefId}].blockPolicy: {blockError}");
+
+                var affectsRaw = ev.defaultAffects ?? new List<string>();
+                if (!DataRegistry.TryParseAffectScopes(affectsRaw, out _, out var affectsError))
+                    errors.Add($"Events[{ev.eventDefId}].defaultAffects: {affectsError}");
+
+                if (!string.IsNullOrEmpty(ev.ignoreApplyMode) && !DataRegistry.TryParseIgnoreApplyMode(ev.ignoreApplyMode, out _, out var modeError))
+                    errors.Add($"Events[{ev.eventDefId}].ignoreApplyMode: {modeError}");
+            }
+
+            foreach (var opt in registry.Root.eventOptions ?? new List<EventOptionDef>())
+            {
+                if (opt == null) continue;
+                if (opt.affects != null && opt.affects.Count > 0)
+                {
+                    if (!DataRegistry.TryParseAffectScopes(opt.affects, out _, out var affectsError))
+                        errors.Add($"EventOptions[{opt.eventDefId}/{opt.optionId}].affects: {affectsError}");
+                }
+            }
+
+            foreach (var row in registry.Root.effectOps ?? new List<EffectOpRow>())
+            {
+                if (row == null) continue;
+                if (!DataRegistry.TryParseAffectScopes(row.scope, out _, out var scopeError))
+                    errors.Add($"EffectOps[{row.effectId}].scope: {scopeError}");
+                if (!DataRegistry.TryParseEffectOpType(row.op, out _, out var opError))
+                    errors.Add($"EffectOps[{row.effectId}].op: {opError}");
+            }
+
+            foreach (var trigger in registry.Root.eventTriggers ?? new List<EventTriggerRow>())
+            {
+                if (trigger == null || string.IsNullOrEmpty(trigger.taskType)) continue;
+                if (!DataRegistry.TryParseTaskType(trigger.taskType, out _, out var taskTypeError))
+                    errors.Add($"EventTriggers[{trigger.eventDefId}].taskType: {taskTypeError}");
+            }
+        }
+
+        private static void ValidateForeignKeys(DataRegistry registry, List<string> errors)
+        {
+            foreach (var opt in registry.Root.eventOptions ?? new List<EventOptionDef>())
+            {
+                if (opt == null) continue;
+                if (string.IsNullOrEmpty(opt.eventDefId) || !registry.EventsById.ContainsKey(opt.eventDefId))
+                    errors.Add($"EventOptions[{opt.optionId}] references missing eventDefId={opt.eventDefId}");
+                if (!string.IsNullOrEmpty(opt.effectId) && !registry.EffectsById.ContainsKey(opt.effectId))
+                    errors.Add($"EventOptions[{opt.eventDefId}/{opt.optionId}] references missing effectId={opt.effectId}");
+            }
+
+            foreach (var ev in registry.Root.events ?? new List<EventDef>())
+            {
+                if (ev == null) continue;
+                if (!string.IsNullOrEmpty(ev.ignoreEffectId) && !registry.EffectsById.ContainsKey(ev.ignoreEffectId))
+                    errors.Add($"Events[{ev.eventDefId}] references missing ignoreEffectId={ev.ignoreEffectId}");
+            }
+
+            foreach (var row in registry.Root.effectOps ?? new List<EffectOpRow>())
+            {
+                if (row == null) continue;
+                if (string.IsNullOrEmpty(row.effectId) || !registry.EffectsById.ContainsKey(row.effectId))
+                    errors.Add($"EffectOps references missing effectId={row.effectId}");
+            }
+
+            foreach (var trigger in registry.Root.eventTriggers ?? new List<EventTriggerRow>())
+            {
+                if (trigger == null) continue;
+                if (string.IsNullOrEmpty(trigger.eventDefId) || !registry.EventsById.ContainsKey(trigger.eventDefId))
+                    errors.Add($"EventTriggers references missing eventDefId={trigger.eventDefId}");
+            }
+
+            var duplicates = registry.Root.eventOptions
+                ?.Where(o => o != null)
+                .GroupBy(o => (o.eventDefId, o.optionId))
+                .Where(g => g.Count() > 1)
+                .Select(g => $"EventOptions duplicate key ({g.Key.eventDefId},{g.Key.optionId})")
+                .ToList();
+            if (duplicates != null && duplicates.Count > 0) errors.AddRange(duplicates);
+        }
+
+        private static void ValidateTriggers(DataRegistry registry, List<string> errors)
+        {
+            foreach (var trigger in registry.Root.eventTriggers ?? new List<EventTriggerRow>())
+            {
+                if (trigger == null) continue;
+                if (trigger.minDay.HasValue && trigger.maxDay.HasValue && trigger.minDay.Value > trigger.maxDay.Value)
+                {
+                    errors.Add($"EventTriggers[{trigger.eventDefId}] invalid day range: {trigger.minDay}>{trigger.maxDay}");
+                }
+
+                if (trigger.minLocalPanic.HasValue && trigger.minLocalPanic.Value < 0)
+                {
+                    errors.Add($"EventTriggers[{trigger.eventDefId}] minLocalPanic < 0");
+                }
+            }
+        }
+
+        private static void ValidateBlockOriginTaskLogic(DataRegistry registry, List<string> errors)
+        {
+            foreach (var ev in registry.Root.events ?? new List<EventDef>())
+            {
+                if (ev == null || string.IsNullOrEmpty(ev.eventDefId)) continue;
+                if (!DataRegistry.TryParseBlockPolicy(ev.blockPolicy, out var policy, out _)) continue;
+                if (policy != BlockPolicy.BlockOriginTask) continue;
+
+                var relatedEffectIds = new List<string>();
+                if (!string.IsNullOrEmpty(ev.ignoreEffectId)) relatedEffectIds.Add(ev.ignoreEffectId);
+                if (registry.OptionsByEvent.TryGetValue(ev.eventDefId, out var options))
+                {
+                    relatedEffectIds.AddRange(options.Where(o => !string.IsNullOrEmpty(o.effectId)).Select(o => o.effectId));
+                }
+
+                bool hasOriginTaskProgressAdd = relatedEffectIds
+                    .Distinct()
+                    .SelectMany(id => registry.EffectOpsByEffectId.TryGetValue(id, out var ops) ? ops : new List<EffectOp>())
+                    .Any(op => op.Scope.Kind == AffectScopeKind.OriginTask &&
+                               string.Equals(op.StatKey, "TaskProgressDelta", StringComparison.OrdinalIgnoreCase) &&
+                               op.Op == EffectOpType.Add);
+
+                if (!hasOriginTaskProgressAdd)
+                {
+                    errors.Add($"Events[{ev.eventDefId}] BlockOriginTask requires OriginTask TaskProgressDelta Add op.");
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/UIPanelRoot.cs
+++ b/Assets/Scripts/UI/UIPanelRoot.cs
@@ -314,11 +314,11 @@ public class UIPanelRoot : MonoBehaviour
 
         _suppressAutoOpenEvent = true;
         var ev = node.PendingEvents[0];
-        Debug.Log($"[EventUI] OpenNodeEvent node={nodeId} eventId={ev.EventId} pending={node.PendingEvents.Count}");
+        Debug.Log($"[EventUI] OpenNodeEvent node={nodeId} eventInstanceId={ev.EventInstanceId} pending={node.PendingEvents.Count}");
         _eventPanel.Show(ev, optionId =>
         {
             _suppressAutoOpenEvent = true;
-            var res = GameController.I.ResolveEvent(nodeId, ev.EventId, optionId);
+            var res = GameController.I.ResolveEvent(nodeId, ev.EventInstanceId, optionId);
             return res.text;
         }, onClose: null);
     }

--- a/Assets/StreamingAssets/game_data.json
+++ b/Assets/StreamingAssets/game_data.json
@@ -1,0 +1,365 @@
+{
+  "meta": {
+    "schemaVersion": "0.1",
+    "dataVersion": "2026.01.24a",
+    "comment": "Minimal sample for data pipeline"
+  },
+  "balance": {
+    "LocalPanicHighThreshold": {
+      "value": "6",
+      "type": "int",
+      "comment": "Local panic trigger"
+    },
+    "RandomEventBaseProb": {
+      "value": "0.35",
+      "type": "float",
+      "comment": "Random event probability"
+    },
+    "DefaultAutoResolveAfterDays": {
+      "value": "0",
+      "type": "int",
+      "comment": "Unused in v0"
+    },
+    "DefaultIgnoreApplyMode": {
+      "value": "ApplyDailyKeep",
+      "type": "enum",
+      "comment": "Default ignore mode"
+    }
+  },
+  "nodes": [
+    {
+      "nodeId": "N1",
+      "name": "节点1",
+      "tags": [
+        "urban",
+        "lab"
+      ],
+      "startLocalPanic": 2,
+      "startPopulation": 12,
+      "startAnomalyIds": [
+        "AN_001"
+      ]
+    },
+    {
+      "nodeId": "N2",
+      "name": "节点2",
+      "tags": [
+        "rural"
+      ],
+      "startLocalPanic": 1,
+      "startPopulation": 9,
+      "startAnomalyIds": []
+    },
+    {
+      "nodeId": "N3",
+      "name": "节点3",
+      "tags": [
+        "urban"
+      ],
+      "startLocalPanic": 0,
+      "startPopulation": 10,
+      "startAnomalyIds": [
+        "AN_002"
+      ]
+    }
+  ],
+  "anomalies": [
+    {
+      "anomalyId": "AN_001",
+      "name": "镜面渗漏",
+      "class": "Euclid",
+      "tags": [
+        "bio",
+        "stealth"
+      ],
+      "baseThreat": 2,
+      "investigateDifficulty": 3,
+      "containDifficulty": 4,
+      "manageRisk": 2
+    },
+    {
+      "anomalyId": "AN_002",
+      "name": "失声合唱",
+      "class": "Keter",
+      "tags": [
+        "memetic",
+        "panic"
+      ],
+      "baseThreat": 3,
+      "investigateDifficulty": 5,
+      "containDifficulty": 6,
+      "manageRisk": 4
+    }
+  ],
+  "taskDefs": [
+    {
+      "taskDefId": "TASK_INVESTIGATE",
+      "taskType": "Investigate",
+      "name": "调查",
+      "baseDays": 5,
+      "progressPerDay": 0.12,
+      "agentSlotsMin": 1,
+      "agentSlotsMax": 3,
+      "yieldKey": "Intel",
+      "yieldPerDay": 1
+    },
+    {
+      "taskDefId": "TASK_CONTAIN",
+      "taskType": "Contain",
+      "name": "收容",
+      "baseDays": 6,
+      "progressPerDay": 0.1,
+      "agentSlotsMin": 1,
+      "agentSlotsMax": 3,
+      "yieldKey": "Money",
+      "yieldPerDay": 0
+    },
+    {
+      "taskDefId": "TASK_MANAGE",
+      "taskType": "Manage",
+      "name": "管理",
+      "baseDays": 999,
+      "progressPerDay": 0.02,
+      "agentSlotsMin": 1,
+      "agentSlotsMax": 2,
+      "yieldKey": "NegEntropy",
+      "yieldPerDay": 2
+    }
+  ],
+  "events": [
+    {
+      "eventDefId": "EVT_INVESTIGATE_SPOTTED",
+      "source": "Investigate",
+      "causeType": "TaskInvestigate",
+      "weight": 10,
+      "title": "调查暴露",
+      "desc": "调查行动被目击，必须立即回应。",
+      "blockPolicy": "BlockOriginTask",
+      "defaultAffects": [
+        "OriginTask",
+        "Node"
+      ],
+      "autoResolveAfterDays": 0,
+      "ignoreApplyMode": "ApplyDailyKeep",
+      "ignoreEffectId": "EFF_IGNORE_INV"
+    },
+    {
+      "eventDefId": "EVT_RANDOM_SHORTAGE",
+      "source": "Random",
+      "causeType": "Random",
+      "weight": 6,
+      "title": "补给短缺",
+      "desc": "供应链出现波动，需要做出取舍。",
+      "blockPolicy": "None",
+      "defaultAffects": [
+        "Node"
+      ],
+      "autoResolveAfterDays": 0,
+      "ignoreApplyMode": "ApplyOnceThenRemove",
+      "ignoreEffectId": "EFF_IGNORE_RANDOM"
+    }
+  ],
+  "eventOptions": [
+    {
+      "eventDefId": "EVT_INVESTIGATE_SPOTTED",
+      "optionId": "O1",
+      "text": "安抚目击者",
+      "resultText": "舆情暂时稳定。",
+      "affects": [
+        "Node"
+      ],
+      "effectId": "EFF_OPTION_CALM"
+    },
+    {
+      "eventDefId": "EVT_INVESTIGATE_SPOTTED",
+      "optionId": "O2",
+      "text": "加速推进任务",
+      "resultText": "调查小队冒险推进，压力上升。",
+      "affects": [
+        "OriginTask",
+        "Global"
+      ],
+      "effectId": "EFF_OPTION_PUSH"
+    },
+    {
+      "eventDefId": "EVT_RANDOM_SHORTAGE",
+      "optionId": "O1",
+      "text": "优先保障民生",
+      "resultText": "民众情绪稳定，但经费吃紧。",
+      "affects": [
+        "Node",
+        "Global"
+      ],
+      "effectId": "EFF_OPTION_RELIEF"
+    },
+    {
+      "eventDefId": "EVT_RANDOM_SHORTAGE",
+      "optionId": "O2",
+      "text": "保障项目推进",
+      "resultText": "项目得到资源，人口受到影响。",
+      "affects": [
+        "Node",
+        "TaskType:Contain"
+      ],
+      "effectId": "EFF_OPTION_PROJECT"
+    }
+  ],
+  "effects": [
+    {
+      "effectId": "EFF_IGNORE_INV",
+      "comment": "调查事件忽略惩罚"
+    },
+    {
+      "effectId": "EFF_OPTION_CALM",
+      "comment": "安抚目击者"
+    },
+    {
+      "effectId": "EFF_OPTION_PUSH",
+      "comment": "加速推进任务"
+    },
+    {
+      "effectId": "EFF_IGNORE_RANDOM",
+      "comment": "随机事件忽略惩罚"
+    },
+    {
+      "effectId": "EFF_OPTION_RELIEF",
+      "comment": "保障民生"
+    },
+    {
+      "effectId": "EFF_OPTION_PROJECT",
+      "comment": "保障项目推进"
+    }
+  ],
+  "effectOps": [
+    {
+      "effectId": "EFF_IGNORE_INV",
+      "scope": "OriginTask",
+      "statKey": "TaskProgressDelta",
+      "op": "Add",
+      "value": -0.2,
+      "min": null,
+      "max": null,
+      "comment": "忽略将倒退任务进度"
+    },
+    {
+      "effectId": "EFF_IGNORE_INV",
+      "scope": "Node",
+      "statKey": "LocalPanic",
+      "op": "Add",
+      "value": 1,
+      "min": null,
+      "max": null,
+      "comment": "忽略提升本地恐慌"
+    },
+    {
+      "effectId": "EFF_OPTION_CALM",
+      "scope": "Node",
+      "statKey": "LocalPanic",
+      "op": "Add",
+      "value": -2,
+      "min": null,
+      "max": null,
+      "comment": "降低本地恐慌"
+    },
+    {
+      "effectId": "EFF_OPTION_PUSH",
+      "scope": "OriginTask",
+      "statKey": "TaskProgressDelta",
+      "op": "Add",
+      "value": 0.15,
+      "min": null,
+      "max": null,
+      "comment": "来源任务获得推进"
+    },
+    {
+      "effectId": "EFF_OPTION_PUSH",
+      "scope": "Global",
+      "statKey": "WorldPanic",
+      "op": "Add",
+      "value": 1,
+      "min": null,
+      "max": null,
+      "comment": "全局恐慌上升"
+    },
+    {
+      "effectId": "EFF_IGNORE_RANDOM",
+      "scope": "Node",
+      "statKey": "LocalPanic",
+      "op": "Add",
+      "value": 1,
+      "min": null,
+      "max": null,
+      "comment": "忽略会增加恐慌"
+    },
+    {
+      "effectId": "EFF_OPTION_RELIEF",
+      "scope": "Node",
+      "statKey": "LocalPanic",
+      "op": "Add",
+      "value": -1,
+      "min": null,
+      "max": null,
+      "comment": "稳定情绪"
+    },
+    {
+      "effectId": "EFF_OPTION_RELIEF",
+      "scope": "Global",
+      "statKey": "Money",
+      "op": "Add",
+      "value": -80,
+      "min": null,
+      "max": null,
+      "comment": "经费消耗"
+    },
+    {
+      "effectId": "EFF_OPTION_PROJECT",
+      "scope": "Node",
+      "statKey": "Population",
+      "op": "Add",
+      "value": -1,
+      "min": null,
+      "max": null,
+      "comment": "人口损失"
+    },
+    {
+      "effectId": "EFF_OPTION_PROJECT",
+      "scope": "TaskType:Contain",
+      "statKey": "TaskProgressDelta",
+      "op": "Add",
+      "value": 0.1,
+      "min": null,
+      "max": null,
+      "comment": "收容任务推进"
+    }
+  ],
+  "eventTriggers": [
+    {
+      "eventDefId": "EVT_INVESTIGATE_SPOTTED",
+      "minDay": 1,
+      "maxDay": null,
+      "requiresNodeTagsAny": [],
+      "requiresNodeTagsAll": [],
+      "requiresAnomalyTagsAny": [
+        "stealth"
+      ],
+      "requiresSecured": false,
+      "minLocalPanic": 0,
+      "taskType": "Investigate",
+      "onlyAffectOriginTask": true
+    },
+    {
+      "eventDefId": "EVT_RANDOM_SHORTAGE",
+      "minDay": 1,
+      "maxDay": null,
+      "requiresNodeTagsAny": [
+        "urban"
+      ],
+      "requiresNodeTagsAll": [],
+      "requiresAnomalyTagsAny": [],
+      "requiresSecured": null,
+      "minLocalPanic": null,
+      "taskType": "",
+      "onlyAffectOriginTask": false
+    }
+  ]
+}

--- a/tools/xlsx_to_json.py
+++ b/tools/xlsx_to_json.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Export game_data.xlsx into Unity-friendly game_data.json."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from openpyxl import load_workbook
+
+LIST_SPLIT = ";"
+
+
+def split_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.split(LIST_SPLIT) if part.strip()]
+
+
+def to_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def to_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes"}:
+        return True
+    if text in {"0", "false", "no"}:
+        return False
+    raise ValueError(f"Cannot parse bool from: {value!r}")
+
+
+def sheet_rows(ws) -> list[dict[str, Any]]:
+    rows = list(ws.iter_rows(values_only=True))
+    if not rows:
+        return []
+    header = [str(col).strip() if col is not None else "" for col in rows[0]]
+    result: list[dict[str, Any]] = []
+    for row in rows[1:]:
+        if row is None:
+            continue
+        entry = {}
+        has_value = False
+        for key, cell in zip(header, row):
+            if not key:
+                continue
+            entry[key] = cell
+            has_value = has_value or cell not in (None, "")
+        if has_value:
+            result.append(entry)
+    return result
+
+
+def load_meta(ws) -> dict[str, Any]:
+    rows = sheet_rows(ws)
+    if not rows:
+        return {}
+    row = rows[0]
+    return {
+        "schemaVersion": str(row.get("schemaVersion", "")).strip(),
+        "dataVersion": str(row.get("dataVersion", "")).strip(),
+        "comment": str(row.get("comment", "")).strip(),
+    }
+
+
+def load_balance(ws) -> dict[str, Any]:
+    balance: dict[str, Any] = {}
+    for row in sheet_rows(ws):
+        key = str(row.get("key", "")).strip()
+        if not key:
+            continue
+        balance[key] = {
+            "value": "" if row.get("value") is None else str(row.get("value")),
+            "type": "" if row.get("type") is None else str(row.get("type")),
+            "comment": "" if row.get("comment") is None else str(row.get("comment")),
+        }
+    return balance
+
+
+def load_nodes(ws) -> list[dict[str, Any]]:
+    nodes: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        nodes.append(
+            {
+                "nodeId": str(row.get("nodeId", "")).strip(),
+                "name": str(row.get("name", "")).strip(),
+                "tags": split_list(row.get("tags")),
+                "startLocalPanic": to_int(row.get("startLocalPanic")) or 0,
+                "startPopulation": to_int(row.get("startPopulation")) or 0,
+                "startAnomalyIds": split_list(row.get("startAnomalyIds")),
+            }
+        )
+    return nodes
+
+
+def load_anomalies(ws) -> list[dict[str, Any]]:
+    anomalies: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        anomalies.append(
+            {
+                "anomalyId": str(row.get("anomalyId", "")).strip(),
+                "name": str(row.get("name", "")).strip(),
+                "class": str(row.get("class", "")).strip(),
+                "tags": split_list(row.get("tags")),
+                "baseThreat": to_int(row.get("baseThreat")) or 0,
+                "investigateDifficulty": to_int(row.get("investigateDifficulty")) or 0,
+                "containDifficulty": to_int(row.get("containDifficulty")) or 0,
+                "manageRisk": to_int(row.get("manageRisk")) or 0,
+            }
+        )
+    return anomalies
+
+
+def load_task_defs(ws) -> list[dict[str, Any]]:
+    task_defs: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        task_defs.append(
+            {
+                "taskDefId": str(row.get("taskDefId", "")).strip(),
+                "taskType": str(row.get("taskType", "")).strip(),
+                "name": str(row.get("name", "")).strip(),
+                "baseDays": to_int(row.get("baseDays")) or 0,
+                "progressPerDay": to_float(row.get("progressPerDay")) or 0.0,
+                "agentSlotsMin": to_int(row.get("agentSlotsMin")) or 0,
+                "agentSlotsMax": to_int(row.get("agentSlotsMax")) or 0,
+                "yieldKey": "" if row.get("yieldKey") is None else str(row.get("yieldKey")),
+                "yieldPerDay": to_float(row.get("yieldPerDay")) or 0.0,
+            }
+        )
+    return task_defs
+
+
+def load_events(ws) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        events.append(
+            {
+                "eventDefId": str(row.get("eventDefId", "")).strip(),
+                "source": str(row.get("source", "")).strip(),
+                "causeType": str(row.get("causeType", "")).strip(),
+                "weight": to_int(row.get("weight")) or 1,
+                "title": str(row.get("title", "")).strip(),
+                "desc": str(row.get("desc", "")).strip(),
+                "blockPolicy": str(row.get("blockPolicy", "")).strip(),
+                "defaultAffects": split_list(row.get("defaultAffects")),
+                "autoResolveAfterDays": to_int(row.get("autoResolveAfterDays")) or 0,
+                "ignoreApplyMode": "" if row.get("ignoreApplyMode") is None else str(row.get("ignoreApplyMode")),
+                "ignoreEffectId": "" if row.get("ignoreEffectId") is None else str(row.get("ignoreEffectId")),
+            }
+        )
+    return events
+
+
+def load_event_options(ws) -> list[dict[str, Any]]:
+    options: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        options.append(
+            {
+                "eventDefId": str(row.get("eventDefId", "")).strip(),
+                "optionId": str(row.get("optionId", "")).strip(),
+                "text": str(row.get("text", "")).strip(),
+                "resultText": str(row.get("resultText", "")).strip(),
+                "affects": split_list(row.get("affects")),
+                "effectId": str(row.get("effectId", "")).strip(),
+            }
+        )
+    return options
+
+
+def load_effects(ws) -> list[dict[str, Any]]:
+    effects: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        effects.append(
+            {
+                "effectId": str(row.get("effectId", "")).strip(),
+                "comment": "" if row.get("comment") is None else str(row.get("comment")),
+            }
+        )
+    return effects
+
+
+def load_effect_ops(ws) -> list[dict[str, Any]]:
+    ops: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        entry = {
+            "effectId": str(row.get("effectId", "")).strip(),
+            "scope": str(row.get("scope", "")).strip(),
+            "statKey": str(row.get("statKey", "")).strip(),
+            "op": str(row.get("op", "")).strip(),
+            "value": to_float(row.get("value")) or 0.0,
+            "min": to_float(row.get("min")),
+            "max": to_float(row.get("max")),
+            "comment": "" if row.get("comment") is None else str(row.get("comment")),
+        }
+        ops.append(entry)
+    return ops
+
+
+def load_triggers(ws) -> list[dict[str, Any]]:
+    triggers: list[dict[str, Any]] = []
+    for row in sheet_rows(ws):
+        triggers.append(
+            {
+                "eventDefId": str(row.get("eventDefId", "")).strip(),
+                "minDay": to_int(row.get("minDay")),
+                "maxDay": to_int(row.get("maxDay")),
+                "requiresNodeTagsAny": split_list(row.get("requiresNodeTagsAny")),
+                "requiresNodeTagsAll": split_list(row.get("requiresNodeTagsAll")),
+                "requiresAnomalyTagsAny": split_list(row.get("requiresAnomalyTagsAny")),
+                "requiresSecured": to_bool(row.get("requiresSecured")),
+                "minLocalPanic": to_int(row.get("minLocalPanic")),
+                "taskType": "" if row.get("taskType") is None else str(row.get("taskType")),
+                "onlyAffectOriginTask": to_bool(row.get("onlyAffectOriginTask")),
+            }
+        )
+    return triggers
+
+
+def export_game_data(xlsx_path: Path, json_path: Path) -> None:
+    wb = load_workbook(xlsx_path)
+
+    data = {
+        "meta": load_meta(wb["Meta"]),
+        "balance": load_balance(wb["Balance"]),
+        "nodes": load_nodes(wb["Nodes"]),
+        "anomalies": load_anomalies(wb["Anomalies"]),
+        "taskDefs": load_task_defs(wb["TaskDefs"]),
+        "events": load_events(wb["Events"]),
+        "eventOptions": load_event_options(wb["EventOptions"]),
+        "effects": load_effects(wb["Effects"]),
+        "effectOps": load_effect_ops(wb["EffectOps"]),
+        "eventTriggers": load_triggers(wb["EventTriggers"]),
+    }
+
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("xlsx", type=Path, help="Path to game_data.xlsx")
+    parser.add_argument("json", type=Path, help="Path to output game_data.json")
+    args = parser.parse_args()
+
+    export_game_data(args.xlsx, args.json)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Remove the committed Excel artifact so the repository does not contain binary XLSX samples and can be submitted without large/opaque assets.

### Description
- Delete the committed file `Assets/StreamingAssets/game_data.xlsx` while keeping the JSON source `Assets/StreamingAssets/game_data.json` and the local conversion tool `tools/xlsx_to_json.py` for developers who need to regenerate JSON locally.
- Commit recorded the removal and updated the working tree to be clean.

### Testing
- Ran `python - <<'PY'\nfrom pathlib import Path\np = Path('Assets/StreamingAssets/game_data.xlsx')\nprint('exists', p.exists())\nPY` to confirm the XLSX file is absent; output showed `exists False` (success).
- Verified a clean repository state with `git status --porcelain`; there are no pending changes (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749dc53d488322b2de934cb781fd36)