### PR TITLE
Switch to Newtonsoft.Json and add package for Unity JSON support

### DIFF
--- a/Assets/Scripts/Data/DataRegistry.cs
+++ b/Assets/Scripts/Data/DataRegistry.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using Core;
+using Newtonsoft.Json;
 using UnityEngine;
 
 namespace Data
@@ -136,12 +136,12 @@ namespace Data
             try
             {
                 var json = File.ReadAllText(path);
-                var options = new JsonSerializerOptions
+                var settings = new JsonSerializerSettings
                 {
-                    IncludeFields = true,
-                    PropertyNameCaseInsensitive = true,
+                    MissingMemberHandling = MissingMemberHandling.Ignore,
+                    NullValueHandling = NullValueHandling.Include,
                 };
-                Root = JsonSerializer.Deserialize<GameDataRoot>(json, options) ?? new GameDataRoot();
+                Root = JsonConvert.DeserializeObject<GameDataRoot>(json, settings) ?? new GameDataRoot();
             }
             catch (Exception ex)
             {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -51,6 +51,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.nuget.newtonsoft-json": "3.2.1"
   }
 }


### PR DESCRIPTION
### Motivation

- The Unity runtime does not provide `System.Text.Json`, causing missing assembly errors when deserializing game data, so a supported JSON library must be used.

### Description

- Replaced `using System.Text.Json` with `using Newtonsoft.Json` in `Assets/Scripts/Data/DataRegistry.cs`.
- Replaced `JsonSerializer.Deserialize` usage with `JsonConvert.DeserializeObject<GameDataRoot>(json, settings)` and added tolerant `JsonSerializerSettings` (`MissingMemberHandling.Ignore`, `NullValueHandling.Include`).
- Added the `com.unity.nuget.newtonsoft-json` package (version `3.2.1`) to `Packages/manifest.json` to ensure Newtonsoft is available at runtime.

### Testing

- Ran `rg "System.Text.Json" -n` to confirm there are no remaining references to `System.Text.Json`, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b20913448322b7dea504eaeb2e10)