### PR TITLE
Fix tuple fallback naming in GameController

### DIFF
--- a/Assets/Scripts/Runtime/GameController.cs
+++ b/Assets/Scripts/Runtime/GameController.cs
@@ -54,7 +54,7 @@ public class GameController : MonoBehaviour
 
         foreach (var nodeDef in DataRegistry.Instance.NodesById.Values.OrderBy(n => n.nodeId))
         {
-            var coord = nodeCoords.TryGetValue(nodeDef.nodeId, out var c) ? c : (0.5f, 0.5f);
+            var coord = nodeCoords.TryGetValue(nodeDef.nodeId, out var c) ? c : (x: 0.5f, y: 0.5f);
             var nodeState = new NodeState
             {
                 Id = nodeDef.nodeId,


### PR DESCRIPTION
### Motivation
- Resolve CS1061 compile errors where `coord.x` and `coord.y` were not found because the tuple fallback lacked named elements.

### Description
- Update `Assets/Scripts/Runtime/GameController.cs` to use a named tuple fallback ` (x: 0.5f, y: 0.5f)` so `coord.x` and `coord.y` compile correctly.

### Testing
- Attempted `dotnet build SCP.slnx`, but the `dotnet` CLI is not available in the container so the project build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b30c9e3883229904e812f3d4cd1e)