### PR TITLE
GameData: Improve build logging and pip dependency handling

### DIFF
--- a/Assets/Scripts/Editor/GameDataBuildMenu.cs
+++ b/Assets/Scripts/Editor/GameDataBuildMenu.cs
@@ -157,7 +157,7 @@ public static class GameDataBuildMenu
     {
         RunProcess(repoRoot, pythonExe, $"-m pip show {packageName}", out var showStdout, out var showStderr, out var showExitCode);
         LogOutput(showStdout, false);
-        LogOutput(showStderr, showExitCode != 0);
+        LogOutput(showStderr, false);
         if (showExitCode == 0) return true;
 
         Debug.Log($"[GameData] Installing missing Python dependency: {packageName}");
@@ -174,15 +174,44 @@ public static class GameDataBuildMenu
         return installExitCode == 0;
     }
 
-    private static void LogOutput(string text, bool isError)
+    private static void LogOutput(string text, bool isStderr)
     {
         if (string.IsNullOrWhiteSpace(text)) return;
         var lines = text.Replace("\r\n", "\n").Split('\n');
         foreach (var line in lines)
         {
             if (string.IsNullOrWhiteSpace(line)) continue;
-            if (isError) Debug.LogError(line);
-            else Debug.Log(line);
+            LogLineSmart(line, isStderr);
+        }
+    }
+
+    private static void LogLineSmart(string line, bool isStderr)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return;
+
+        if (isStderr)
+        {
+            Debug.LogError(line);
+            return;
+        }
+
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("[ERROR]", StringComparison.Ordinal))
+        {
+            Debug.LogError(line);
+        }
+        else if (trimmed.StartsWith("[WARN]", StringComparison.Ordinal))
+        {
+            Debug.LogWarning(line);
+        }
+        else if (trimmed.StartsWith("[SUCCESS]", StringComparison.Ordinal)
+            || trimmed.StartsWith("[INFO]", StringComparison.Ordinal))
+        {
+            Debug.Log(line);
+        }
+        else
+        {
+            Debug.Log(line);
         }
     }
 


### PR DESCRIPTION
### Motivation
- The previous logging sent many `stdout` lines (including `[INFO]`) to `Debug.LogError`, making the Console unreadable.
- `stdout` should be normal logs while `stderr` should be errors, and lines with explicit prefixes should be honored.
- `EnsurePythonDependency` should not treat `pip show` stderr as a hard error unless the check or install fails (non-zero exit).

### Description
- Adjusted `EnsurePythonDependency` to log `pip show` stderr via `LogOutput(..., false)` so it is not forced to error if `showExitCode != 0`.
- Reworked `LogOutput` to accept an `isStderr` flag and route per-line output through a new `LogLineSmart` helper.
- Implemented `LogLineSmart` which sends `isStderr` lines to `Debug.LogError` and parses stdout prefixes so `[ERROR]` -> `Debug.LogError`, `[WARN]` -> `Debug.LogWarning`, and `[SUCCESS]`/`[INFO]` -> `Debug.Log`.
- Kept install-time stderr treated as error when `installExitCode != 0`, so real failures still surface as red errors.

### Testing
- No automated tests were run for this editor-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756479dc708322a50526588efdc0b4)