### PR TITLE
Data-driven events: DataRegistry loader, validation, and event flow adjustments

### DIFF
--- a/Assets/Scripts/Core/NodeEvents.cs
+++ b/Assets/Scripts/Core/NodeEvents.cs
@@ -22,7 +22,6 @@ namespace Core
         public string EventDefId;
         public string NodeId;
         public int CreatedDay;
-        public CauseType CauseType;
         public string SourceTaskId;
         public string SourceAnomalyId;
 
@@ -32,7 +31,7 @@ namespace Core
 
     public static class EventInstanceFactory
     {
-        public static EventInstance Create(string eventDefId, string nodeId, int day, CauseType causeType, string sourceTaskId = null, string sourceAnomalyId = null)
+        public static EventInstance Create(string eventDefId, string nodeId, int day, string sourceTaskId = null, string sourceAnomalyId = null)
         {
             return new EventInstance
             {
@@ -40,7 +39,6 @@ namespace Core
                 EventDefId = eventDefId,
                 NodeId = nodeId,
                 CreatedDay = day,
-                CauseType = causeType,
                 SourceTaskId = sourceTaskId,
                 SourceAnomalyId = sourceAnomalyId,
                 IgnoreAppliedOnce = false,

--- a/Assets/Scripts/Data/EffectOpExecutor.cs
+++ b/Assets/Scripts/Data/EffectOpExecutor.cs
@@ -17,27 +17,31 @@ namespace Data
 
     public static class EffectOpExecutor
     {
-        public static void ApplyEffect(string effectId, EffectContext ctx, IReadOnlyCollection<AffectScope> allowedScopes = null)
+        public static int ApplyEffect(string effectId, EffectContext ctx, IReadOnlyCollection<AffectScope> allowedScopes = null)
         {
-            if (ctx?.State == null || string.IsNullOrEmpty(effectId)) return;
+            if (ctx?.State == null || string.IsNullOrEmpty(effectId)) return 0;
 
             var registry = DataRegistry.Instance;
             if (!registry.EffectOpsByEffectId.TryGetValue(effectId, out var ops) || ops == null || ops.Count == 0)
             {
                 Debug.LogWarning($"[EffectOpExecutor] effectId={effectId} has no ops.");
-                return;
+                return 0;
             }
 
             var allowedSet = allowedScopes != null && allowedScopes.Count > 0
                 ? new HashSet<string>(allowedScopes.Select(s => s.Raw))
                 : null;
 
+            int applied = 0;
             foreach (var op in ops)
             {
                 if (op == null) continue;
                 if (allowedSet != null && !allowedSet.Contains(op.Scope.Raw)) continue;
                 ApplyOp(op, ctx);
+                applied++;
             }
+
+            return applied;
         }
 
         private static void ApplyOp(EffectOp op, EffectContext ctx)

--- a/Assets/Scripts/UI/EventPanel.cs
+++ b/Assets/Scripts/UI/EventPanel.cs
@@ -54,7 +54,7 @@ public class EventPanel : MonoBehaviour
         _onChoose = onChoose;
         _onClose = onClose;
 
-        registry.OptionsByEvent.TryGetValue(ev.EventDefId, out _options);
+        registry.OptionsByEventId.TryGetValue(ev.EventDefId, out _options);
         _options ??= new List<EventOptionDef>();
 
         resultText.text = string.Empty;


### PR DESCRIPTION
### Motivation
- Move event configuration out of hardcoded stubs into a single data source (`Assets/StreamingAssets/game_data.json`) and provide a unified loader for different platforms (Editor/Standalone/WebGL).  
- Provide strong referential and enum validation for event/effect/trigger data so data issues fail fast and report exact sheet/row/col info.  
- Reduce runtime save bloat by keeping `EventInstance` as a lightweight reference and make event generation/resolution consult the registry for text/effects while improving diagnostic logs.

### Description
- Added WebGL-aware JSON loading and a summary log in `DataRegistry` (`Assets/Scripts/Data/DataRegistry.cs`) with new helper `LoadJsonText`, `LogSummary`, and renamed/indexed collections `OptionsByEventId` and `TriggersByEventDefId`.  
- Enhanced validator in `GameDataValidator` (`Assets/Scripts/Data/GameDataValidator.cs`) to emit spreadsheet-style diagnostics (`sheet+row+col+value+expected`) and perform indexed foreign-key / uniqueness checks.  
- Made `EffectOpExecutor.ApplyEffect` return the count of applied ops and used that in `Sim` to log `effectsApplied`; logging for event generation and pools was enriched (`Assets/Scripts/Core/Sim.cs`).  
- Slimmed `EventInstance` to only hold `eventDefId` + runtime metadata and updated factory and all call-sites to stop persisting enum `CauseType` into instances (`Assets/Scripts/Core/NodeEvents.cs` and `Assets/Scripts/Core/Sim.cs`).  
- UI now looks up options via the new `OptionsByEventId` index (`Assets/Scripts/UI/EventPanel.cs`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756b4da99083228172a4cc6acccbac)