### PR TITLE
Fix proto_v1 detection for table sheets

### DIFF
--- a/tools/xlsx_to_json.py
+++ b/tools/xlsx_to_json.py
@@ -379,12 +379,18 @@ def _sheet_has_proto_v1(rows: list[tuple[Any, ...]]) -> bool:
     type_row = rows[2]
     if not any(cell is not None and str(cell).strip() for cell in field_row):
         return False
+    saw_marker = False
     for cell in type_row:
         if cell is None:
             continue
-        if str(cell).strip() in TABLE_TYPE_MARKERS:
-            return True
-    return False
+        text = str(cell).strip()
+        if not text:
+            continue
+        if text in TABLE_TYPE_MARKERS:
+            saw_marker = True
+            continue
+        return False
+    return saw_marker
 
 
 def _parse_table_value(type_name: str, value: Any) -> Any:


### PR DESCRIPTION
### Motivation
- The sheet-type detection sometimes misclassified legacy sheets as `proto_v1` when data rows contained marker-like strings, leading to parsing errors (e.g. trying to convert the string `"int"` to `float`).

### Description
- Tighten `_sheet_has_proto_v1` so the type row is considered valid only when all non-empty cells are known `TABLE_TYPE_MARKERS` and at least one marker is present.
- Ignore empty cells in the type row and treat any unknown non-empty token as evidence the sheet is legacy.
- Implemented a `saw_marker` flag to require at least one marker rather than returning true on the first match.

### Testing
- Applied the patch to `tools/xlsx_to_json.py` and updated the file successfully.
- Verified the changed logic via static inspection of the file lines with `nl`/`sed`/`rg`.
- Attempted a runtime probe using a small Python snippet that imports `openpyxl`, but it failed because the `openpyxl` module is not installed, so dynamic validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975978742b4832292eccdd15429687a)