### PR TITLE
Add runtime TableRegistry with typed accessors and startup sanity logs

### DIFF
--- a/Assets/Scripts/Data/DataRegistry.cs
+++ b/Assets/Scripts/Data/DataRegistry.cs
@@ -109,6 +109,7 @@ namespace Data
         public Dictionary<string, List<EffectOp>> EffectOpsByEffectId { get; private set; } = new();
         public Dictionary<string, List<EventTrigger>> TriggersByEventDefId { get; private set; } = new();
         public Dictionary<string, BalanceValue> Balance { get; private set; } = new();
+        public TableRegistry Tables { get; private set; } = new();
 
         public int LocalPanicHighThreshold { get; private set; } = 6;
         public double RandomEventBaseProb { get; private set; } = 0.15d;
@@ -252,6 +253,10 @@ namespace Data
             var defaultIgnoreApplyModeRaw = GetBalanceString("DefaultIgnoreApplyMode", DefaultIgnoreApplyMode.ToString());
             if (TryParseIgnoreApplyMode(defaultIgnoreApplyModeRaw, out var parsedMode, out _))
                 DefaultIgnoreApplyMode = parsedMode;
+
+            Tables = new TableRegistry(Root.tables);
+            Debug.Log($"[Tables] loaded {Tables.TableCount} tables");
+            LogTablesSanity();
         }
 
         private void LogSummary()
@@ -263,6 +268,20 @@ namespace Data
             int triggersCount = Root?.eventTriggers?.Count ?? 0;
 
             Debug.Log($"[Data] schema={schema} dataVersion={dataVersion} events={EventsById.Count} options={optionsCount} effects={EffectsById.Count} ops={opsCount} triggers={triggersCount}");
+        }
+
+        private void LogTablesSanity()
+        {
+            if (Tables == null) return;
+            if (Tables.TryFindFirstValue("test", out var tableName, out var rowId, out var raw))
+            {
+                var value = Tables.GetString(tableName, rowId, "test", raw?.ToString() ?? string.Empty);
+                Debug.Log($"[Tables] sanity {tableName}[{rowId}].test={value}");
+            }
+            else
+            {
+                Debug.LogWarning("[Tables] sanity test column not found");
+            }
         }
 
         private bool TryParseEffectOp(EffectOpRow row, out List<EffectOp> ops)

--- a/Assets/Scripts/Data/GameDataModels.cs
+++ b/Assets/Scripts/Data/GameDataModels.cs
@@ -16,6 +16,7 @@ namespace Data
         public List<EffectDef> effects = new();
         public List<EffectOpRow> effectOps = new();
         public List<EventTriggerRow> eventTriggers = new();
+        public Dictionary<string, GameDataTable> tables = new();
     }
 
     [Serializable]
@@ -132,5 +133,21 @@ namespace Data
         public int? minLocalPanic;
         public string taskType;
         public bool? onlyAffectOriginTask;
+    }
+
+    [Serializable]
+    public class GameDataTable
+    {
+        public string mode;
+        public string idField;
+        public List<GameDataColumn> columns = new();
+        public List<Dictionary<string, object>> rows = new();
+    }
+
+    [Serializable]
+    public class GameDataColumn
+    {
+        public string name;
+        public string type;
     }
 }

--- a/Assets/Scripts/Data/TableRegistry.cs
+++ b/Assets/Scripts/Data/TableRegistry.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Data
+{
+    public sealed class TableRegistry
+    {
+        private static readonly char[] ListSeparators = { ',', ';', '，' };
+        private readonly Dictionary<string, GameDataTable> _tables;
+        private readonly Dictionary<string, Dictionary<string, Dictionary<string, object>>> _rowsByTable;
+
+        public TableRegistry()
+            : this(new Dictionary<string, GameDataTable>())
+        {
+        }
+
+        public TableRegistry(Dictionary<string, GameDataTable> tables)
+        {
+            _tables = tables ?? new Dictionary<string, GameDataTable>();
+            _rowsByTable = new Dictionary<string, Dictionary<string, Dictionary<string, object>>>(StringComparer.Ordinal);
+            BuildIndex();
+        }
+
+        public int TableCount => _tables.Count;
+
+        public bool TryGetRow(string tableName, string rowId, out Dictionary<string, object> row)
+        {
+            row = null;
+            if (string.IsNullOrEmpty(tableName) || string.IsNullOrEmpty(rowId)) return false;
+            if (!_rowsByTable.TryGetValue(tableName, out var tableIndex)) return false;
+            return tableIndex.TryGetValue(rowId, out row);
+        }
+
+        public int GetInt(string tableName, string rowId, string column, int fallback = 0)
+        {
+            if (!TryGetValue(tableName, rowId, column, out var raw)) return fallback;
+            return TryCoerceInt(raw, out var value) ? value : fallback;
+        }
+
+        public float GetFloat(string tableName, string rowId, string column, float fallback = 0f)
+        {
+            if (!TryGetValue(tableName, rowId, column, out var raw)) return fallback;
+            return TryCoerceFloat(raw, out var value) ? value : fallback;
+        }
+
+        public string GetString(string tableName, string rowId, string column, string fallback = "")
+        {
+            if (!TryGetValue(tableName, rowId, column, out var raw)) return fallback;
+            return TryCoerceString(raw, out var value) ? value : fallback;
+        }
+
+        public bool GetBool(string tableName, string rowId, string column, bool fallback = false)
+        {
+            if (!TryGetValue(tableName, rowId, column, out var raw)) return fallback;
+            return TryCoerceBool(raw, out var value) ? value : fallback;
+        }
+
+        public List<string> GetStringList(string tableName, string rowId, string column)
+        {
+            if (!TryGetValue(tableName, rowId, column, out var raw)) return new List<string>();
+            return CoerceStringList(raw);
+        }
+
+        public List<int> GetIntList(string tableName, string rowId, string column)
+        {
+            if (!TryGetValue(tableName, rowId, column, out var raw)) return new List<int>();
+            return CoerceIntList(raw);
+        }
+
+        public List<float> GetFloatList(string tableName, string rowId, string column)
+        {
+            if (!TryGetValue(tableName, rowId, column, out var raw)) return new List<float>();
+            return CoerceFloatList(raw);
+        }
+
+        public bool TryFindFirstValue(string column, out string tableName, out string rowId, out object value)
+        {
+            tableName = null;
+            rowId = null;
+            value = null;
+            if (string.IsNullOrEmpty(column)) return false;
+
+            foreach (var tableEntry in _rowsByTable)
+            {
+                foreach (var rowEntry in tableEntry.Value)
+                {
+                    if (!rowEntry.Value.TryGetValue(column, out var raw)) continue;
+                    tableName = tableEntry.Key;
+                    rowId = rowEntry.Key;
+                    value = raw;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void BuildIndex()
+        {
+            _rowsByTable.Clear();
+            foreach (var entry in _tables)
+            {
+                var tableName = entry.Key;
+                var table = entry.Value;
+                var index = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
+                if (table?.rows == null || string.IsNullOrEmpty(table.idField))
+                {
+                    _rowsByTable[tableName] = index;
+                    continue;
+                }
+
+                foreach (var row in table.rows)
+                {
+                    if (row == null) continue;
+                    if (!TryGetRowId(row, table.idField, out var rowId)) continue;
+                    if (string.IsNullOrEmpty(rowId)) continue;
+                    index[rowId] = row;
+                }
+
+                _rowsByTable[tableName] = index;
+            }
+        }
+
+        private bool TryGetRowId(Dictionary<string, object> row, string idField, out string rowId)
+        {
+            rowId = null;
+            if (row == null || string.IsNullOrEmpty(idField)) return false;
+            if (!row.TryGetValue(idField, out var raw)) return false;
+            if (!TryCoerceString(raw, out rowId)) return false;
+            return !string.IsNullOrEmpty(rowId);
+        }
+
+        private bool TryGetValue(string tableName, string rowId, string column, out object value)
+        {
+            value = null;
+            if (!TryGetRow(tableName, rowId, out var row)) return false;
+            return row.TryGetValue(column, out value);
+        }
+
+        private static bool TryCoerceString(object raw, out string value)
+        {
+            value = null;
+            if (raw == null) return false;
+            switch (raw)
+            {
+                case string str:
+                    value = str;
+                    return true;
+                case JValue jValue:
+                    if (jValue.Value == null) return false;
+                    value = Convert.ToString(jValue.Value, CultureInfo.InvariantCulture);
+                    return true;
+                case JToken token:
+                    value = token.Type == JTokenType.Null ? null : token.ToString();
+                    return value != null;
+                default:
+                    value = Convert.ToString(raw, CultureInfo.InvariantCulture);
+                    return value != null;
+            }
+        }
+
+        private static bool TryCoerceInt(object raw, out int value)
+        {
+            value = 0;
+            if (raw == null) return false;
+            if (raw is JValue jValue)
+            {
+                raw = jValue.Value;
+                if (raw == null) return false;
+            }
+
+            switch (raw)
+            {
+                case int intValue:
+                    value = intValue;
+                    return true;
+                case long longValue:
+                    value = (int)longValue;
+                    return true;
+                case float floatValue:
+                    value = (int)floatValue;
+                    return true;
+                case double doubleValue:
+                    value = (int)doubleValue;
+                    return true;
+                case decimal decimalValue:
+                    value = (int)decimalValue;
+                    return true;
+                case bool boolValue:
+                    value = boolValue ? 1 : 0;
+                    return true;
+                case string str:
+                    return int.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+                default:
+                    return int.TryParse(Convert.ToString(raw, CultureInfo.InvariantCulture), out value);
+            }
+        }
+
+        private static bool TryCoerceFloat(object raw, out float value)
+        {
+            value = 0f;
+            if (raw == null) return false;
+            if (raw is JValue jValue)
+            {
+                raw = jValue.Value;
+                if (raw == null) return false;
+            }
+
+            switch (raw)
+            {
+                case float floatValue:
+                    value = floatValue;
+                    return true;
+                case double doubleValue:
+                    value = (float)doubleValue;
+                    return true;
+                case decimal decimalValue:
+                    value = (float)decimalValue;
+                    return true;
+                case int intValue:
+                    value = intValue;
+                    return true;
+                case long longValue:
+                    value = longValue;
+                    return true;
+                case string str:
+                    return float.TryParse(str, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+                default:
+                    return float.TryParse(Convert.ToString(raw, CultureInfo.InvariantCulture), out value);
+            }
+        }
+
+        private static bool TryCoerceBool(object raw, out bool value)
+        {
+            value = false;
+            if (raw == null) return false;
+            if (raw is JValue jValue)
+            {
+                raw = jValue.Value;
+                if (raw == null) return false;
+            }
+
+            switch (raw)
+            {
+                case bool boolValue:
+                    value = boolValue;
+                    return true;
+                case int intValue:
+                    value = intValue != 0;
+                    return true;
+                case long longValue:
+                    value = longValue != 0;
+                    return true;
+                case float floatValue:
+                    value = Math.Abs(floatValue) > 0f;
+                    return true;
+                case double doubleValue:
+                    value = Math.Abs(doubleValue) > 0d;
+                    return true;
+                case string str:
+                    return TryParseBoolString(str, out value);
+                default:
+                    return TryParseBoolString(Convert.ToString(raw, CultureInfo.InvariantCulture), out value);
+            }
+        }
+
+        private static bool TryParseBoolString(string raw, out bool value)
+        {
+            value = false;
+            if (string.IsNullOrWhiteSpace(raw)) return false;
+            var text = raw.Trim().ToLowerInvariant();
+            if (text is "1" or "true" or "yes")
+            {
+                value = true;
+                return true;
+            }
+
+            if (text is "0" or "false" or "no")
+            {
+                value = false;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static List<string> CoerceStringList(object raw)
+        {
+            var list = CoerceList(raw);
+            if (list == null) return new List<string>();
+            return list.Select(item =>
+            {
+                if (item == null) return string.Empty;
+                if (item is JValue jValue && jValue.Value != null) return Convert.ToString(jValue.Value, CultureInfo.InvariantCulture);
+                return Convert.ToString(item, CultureInfo.InvariantCulture) ?? string.Empty;
+            }).ToList();
+        }
+
+        private static List<int> CoerceIntList(object raw)
+        {
+            var list = CoerceList(raw);
+            if (list == null) return new List<int>();
+            var result = new List<int>();
+            foreach (var item in list)
+            {
+                if (TryCoerceInt(item, out var value))
+                    result.Add(value);
+            }
+            return result;
+        }
+
+        private static List<float> CoerceFloatList(object raw)
+        {
+            var list = CoerceList(raw);
+            if (list == null) return new List<float>();
+            var result = new List<float>();
+            foreach (var item in list)
+            {
+                if (TryCoerceFloat(item, out var value))
+                    result.Add(value);
+            }
+            return result;
+        }
+
+        private static List<object> CoerceList(object raw)
+        {
+            if (raw == null) return null;
+            if (raw is JValue jValue)
+            {
+                raw = jValue.Value;
+                if (raw == null) return null;
+            }
+
+            if (raw is JArray jArray)
+            {
+                return jArray.ToObject<List<object>>() ?? new List<object>();
+            }
+
+            if (raw is IEnumerable<object> enumerable && raw is not string)
+            {
+                return enumerable.ToList();
+            }
+
+            if (raw is System.Collections.IEnumerable genericEnumerable && raw is not string)
+            {
+                var list = new List<object>();
+                foreach (var item in genericEnumerable)
+                {
+                    list.Add(item);
+                }
+                return list;
+            }
+
+            if (raw is string str)
+            {
+                return SplitStringList(str).Cast<object>().ToList();
+            }
+
+            return new List<object> { raw };
+        }
+
+        private static List<string> SplitStringList(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return new List<string>();
+            return raw
+                .Split(ListSeparators, StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Trim())
+                .Where(part => !string.IsNullOrEmpty(part))
+                .ToList();
+        }
+    }
+}

--- a/Assets/Scripts/Data/TableRegistry.cs.meta
+++ b/Assets/Scripts/Data/TableRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a23197bb818d4309b2866041590d2900


### PR DESCRIPTION
### Motivation
- Expose top-level `tables` from `game_data.json` to the Unity runtime so code can read spreadsheet-style tables at runtime. 
- Provide typed, convenient accessors for table values (ints/floats/strings/bools and lists) so gameplay code can consume table data safely. 
- Emit a startup sanity log that verifies a visible test value was loaded while keeping existing `balance/nodes/...` summary logging unchanged.

### Description
- Add `tables` to `GameDataRoot` and new `GameDataTable`/`GameDataColumn` models in `Assets/Scripts/Data/GameDataModels.cs` to represent exported tables. 
- Introduce `TableRegistry` (`Assets/Scripts/Data/TableRegistry.cs`) which indexes tables and rows and exposes typed getters `GetInt`, `GetFloat`, `GetString`, `GetBool`, `GetStringList`, `GetIntList`, `GetFloatList`, plus `TryFindFirstValue`; list parsing accepts `,`, `;`, and `，`. 
- Integrate the registry into `DataRegistry` by adding a `Tables` property, initializing it from `Root.tables`, logging `"[Tables] loaded {count} tables"`, and running `LogTablesSanity()` that prints a sanity read of a `test` column without changing the existing `[Data]` summary. 
- Add Unity `.meta` for the new `TableRegistry` file and commit the new/updated files.

### Testing
- Inspected `game_data.json` with a short Python script (`python - <<'PY' ...`) which succeeded and showed the file keys and that a top-level `tables` key was not present. 
- Attempted to install `openpyxl` via `python -m pip install openpyxl` to parse the XLSX locally but the install failed due to a network/proxy error, so workbook parsing checks were not run. 
- No automated unit tests were executed against the C# changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69759bfc70a48322aeb91bdd4a46ad7d)