### PR TITLE
Validate unique table idField keys

### DIFF
--- a/Assets/Scripts/Data/TableRegistry.cs
+++ b/Assets/Scripts/Data/TableRegistry.cs
@@ -112,11 +112,22 @@ namespace Data
                     continue;
                 }
 
-                foreach (var row in table.rows)
+                var seenRowIds = new Dictionary<string, int>(StringComparer.Ordinal);
+                for (var i = 0; i < table.rows.Count; i++)
                 {
+                    var row = table.rows[i];
                     if (row == null) continue;
                     if (!TryGetRowId(row, table.idField, out var rowId)) continue;
                     if (string.IsNullOrEmpty(rowId)) continue;
+                    if (seenRowIds.TryGetValue(rowId, out var existingRow))
+                    {
+                        var rowNumber = i + 1;
+                        throw new InvalidOperationException(
+                            $"[DataRegistry] Table '{tableName}' idField '{table.idField}' duplicate key '{rowId}' at row {rowNumber} (previous row {existingRow}).");
+                    }
+
+                    var currentRowNumber = i + 1;
+                    seenRowIds[rowId] = currentRowNumber;
                     index[rowId] = row;
                 }
 


### PR DESCRIPTION
### Motivation
- Ensure one-to-many game-data tables (e.g. EventOptions / EffectOps / EventTriggers) have unique id keys when indexing so runtime lookups and GroupBy semantics are reliable.
- Detect and fail fast on duplicate ids to surface data authoring errors with precise location information.
- Keep id keys normalized to string when building the by-id index to avoid type mismatch issues.

### Description
- Add uniqueness enforcement in `TableRegistry.BuildIndex()` that tracks seen `idField` values and throws `InvalidOperationException` when a duplicate key is encountered.  
- The error message includes the table name, `idField` name, the duplicate key value, the duplicated row number and the previous row number.  
- The index build still obtains row ids using `TryGetRowId(...)`, which coerces id values to string, so ById keys are normalized as strings.  
- Change is localized to `Assets/Scripts/Data/TableRegistry.cs` and preserves existing behavior for tables without `idField` or missing rows.

### Testing
- No automated tests were executed for this change.  
- The change was compiled and committed locally (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d65598888322a1c0573434fa2945)