### PR TITLE
Add money and world panic daily settlement (economy + WorldPanic)

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -168,8 +168,11 @@ namespace Core
     public class GameState
     {
         public int Day = 1;
-        public int Money = 1000;
-        public int Panic = 0;
+        public int Money = 0;
+        public float WorldPanic = 0f;
+
+        // 预留字段：Intel（暂不结算）
+        public int Intel = 0;
 
         // 新货币：负熵（由“管理异常”系统每日产出）
         public int NegEntropy = 0;

--- a/Assets/Scripts/Data/EffectOpExecutor.cs
+++ b/Assets/Scripts/Data/EffectOpExecutor.cs
@@ -100,14 +100,19 @@ namespace Data
         private static void ApplyToGlobal(EffectOp op, GameState state)
         {
             if (state == null) return;
+            var registry = DataRegistry.Instance;
 
             if (StatEquals(op.StatKey, "WorldPanic") || StatEquals(op.StatKey, "Panic"))
             {
-                state.Panic = ApplyInt(state.Panic, op, clampMin: 0, clampMax: 100);
+                var next = ApplyFloat(state.WorldPanic, op);
+                float clampMin = registry.GetBalanceFloatWithWarn("ClampWorldPanicMin", 0f);
+                state.WorldPanic = Mathf.Max(clampMin, next);
             }
             else if (StatEquals(op.StatKey, "Money"))
             {
-                state.Money = ApplyInt(state.Money, op);
+                int next = ApplyInt(state.Money, op);
+                int clampMin = registry.GetBalanceIntWithWarn("ClampMoneyMin", 0);
+                state.Money = Math.Max(clampMin, next);
             }
             else if (StatEquals(op.StatKey, "NegEntropy"))
             {

--- a/Assets/Scripts/UI/HUD.cs
+++ b/Assets/Scripts/UI/HUD.cs
@@ -38,7 +38,7 @@ public class HUD : MonoBehaviour
 
     void AutoWireBindingsIfMissing()
     {
-        // HUD 结构：HUD/Panel/End Day, HUD/Panel/NewsBT, 以及 3 个 TMP 文本（day/money/panic）
+        // HUD 结构：HUD/Panel/End Day, HUD/Panel/NewsBT, 以及 3 个 TMP 文本（day/money/world panic）
         // 如果你已经手动拖好了，这里不会覆盖。
         var panel = transform.Find("Panel");
 
@@ -59,7 +59,7 @@ public class HUD : MonoBehaviour
         {
             var tmps = panel.GetComponentsInChildren<TextMeshProUGUI>(true);
             // 层级里显示为 Text (TMP), Text (TMP) (1), Text (TMP) (2) :contentReference[oaicite:1]{index=1}
-            // 我们按出现顺序填充：Day/Money/Panic
+            // 我们按出现顺序填充：Day/Money/WorldPanic
             if (!dayText && tmps.Length > 0) dayText = tmps[0];
             if (!moneyText && tmps.Length > 1) moneyText = tmps[1];
             if (!panicText && tmps.Length > 2) panicText = tmps[2];
@@ -104,7 +104,7 @@ public class HUD : MonoBehaviour
         var s = GameController.I.State;
         if (dayText) dayText.text = $"Day {s.Day}";
         if (moneyText) moneyText.text = $"$ {s.Money}";
-        if (panicText) panicText.text = $"Panic {s.Panic}%";
+        if (panicText) panicText.text = $"WorldPanic {s.WorldPanic:0.##}";
 
         if (debugText)
         {


### PR DESCRIPTION
### Motivation
- Implement the first-pass resource loop (Money) and global threat metric (WorldPanic) so the simulation performs daily economic and panic settlement and can trigger game-over on runaway panic.
- Drive parameters from data tables instead of hard-coded constants and warn when table entries are missing to avoid silent misconfiguration.
- Provide visible HUD feedback and diagnostic logs to make acceptance and debugging easier.

### Description
- Add `Money` (int), `WorldPanic` (float) and reserved `Intel` to `GameState` and stop using the old `Panic` int for global panic state.
- Add table-backed helpers to `DataRegistry` (`GetBalance*WithWarn`, `GetAnomaly*WithWarn`) and robust coercion with `[WARN]` logs for missing/invalid Balance/Anomalies fields.
- Initialize `State.Money` and `State.WorldPanic` in `GameController.Awake()` from `Balance` (with clamps) and add `IsGameOver` plus `MarkGameOver()` to guard `EndDay()` after failure.
- Implement day-end settlement in `Sim.StepDay`: compute `income = Σ floor(node.Population * PopToMoneyRate)`, `wage = AgentCount * WagePerAgentPerDay`, `maintenance = Σ managed anomaly maintenance (fallback to ContainedAnomalyMaintenanceDefault)`, apply money clamp, and log via `[Economy]`.
- Compute `worldPanicAdd = Σ worldPanicPerDayUncontained` for all uncontained anomalies and `worldPanicDecay = DailyWorldPanicDecay + safeNodeCount * WorldPanicDecayPerSafeNodePerDay`, apply to `WorldPanic` with clamp and log via `[WorldPanic]`, and trigger game over when `WorldPanic >= WorldPanicFailThreshold` via `GameController.MarkGameOver()` and `[GameOver]` logging.
- On containment completion apply one-time panic relief `ContainReliefFixed` (table-driven), clamp, and add a debug log; update news message accordingly.
- Update `EffectOpExecutor` to operate on `WorldPanic`/`Money` using the new clamp helpers, and update HUD to display `Money` and `WorldPanic` as plain text.

### Testing
- No automated tests were executed on these changes in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975de06860c83229d1dcc84d1927834)