### PR TITLE
Update Balance accessors to new key/p1/p2/p3 table schema

### DIFF
--- a/Assets/Scripts/Runtime/GameController.cs
+++ b/Assets/Scripts/Runtime/GameController.cs
@@ -45,6 +45,7 @@ public class GameController : MonoBehaviour
         float startWorldPanic = registry.GetBalanceFloatWithWarn("StartWorldPanic", 0f);
         int clampMoneyMin = registry.GetBalanceIntWithWarn("ClampMoneyMin", 0);
         float clampWorldPanicMin = registry.GetBalanceFloatWithWarn("ClampWorldPanicMin", 0f);
+        Debug.Log($"[Balance] StartMoney={startMoney} StartWorldPanic={startWorldPanic} ClampMoneyMin={clampMoneyMin} ClampWorldPanicMin={clampWorldPanicMin}");
         State.Money = Math.Max(clampMoneyMin, startMoney);
         State.WorldPanic = Math.Max(clampWorldPanicMin, startWorldPanic);
 


### PR DESCRIPTION
### Motivation
- Balance data migrated to a new table schema using columns `key`, `p1` (int[]), `p2` (float[]), `p3` (string[]), and old code still read `Balance.<key>.value` causing warnings and sanity failures. 
- The registry needs to read the new columns consistently and stop emitting `Missing table value: Balance.*.value` warnings. 
- Provide a compact startup summary of key Balance values to aid verification.

### Description
- Move `Tables = new TableRegistry(Root.tables)` earlier in `DataRegistry.Reload()` so table-backed Balance accessors are usable during registry initialization. 
- Replace old `GetBalanceInt/Float/String` (which read `Balance.<key>.value`) with implementations that prefer `p1[0]`, `p2[0]`, then `p3[0]` as specified, using `Mathf.RoundToInt` when converting float->int and invariant parsing for strings. 
- Add array helpers `GetBalanceIntArray`, `GetBalanceFloatArray`, and `GetBalanceStringArray` returning `p1`/`p2`/`p3` respectively, and route `GetBalance*WithWarn` to the new logic. 
- Update `LogTablesSanity()` to check that the `Balance` table contains column names `key`, `p1`, `p2`, `p3` and emit the actual column list when columns are missing. 
- Add a one-time info log in `GameController.Awake()`: `"[Balance] StartMoney=... StartWorldPanic=... ClampMoneyMin=... ClampWorldPanicMin=..."` to surface startup values and reduce noisy warnings.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e7dab5448322975c1cc76e039d77)