### PR TITLE
feat: auto resolve pending events by days

### DIFF
--- a/Assets/Scripts/Core/NodeEvents.cs
+++ b/Assets/Scripts/Core/NodeEvents.cs
@@ -22,6 +22,7 @@ namespace Core
         public string EventDefId;
         public string NodeId;
         public int CreatedDay;
+        public int AgeDays;
         public string SourceTaskId;
         public string SourceAnomalyId;
 
@@ -39,6 +40,7 @@ namespace Core
                 EventDefId = eventDefId,
                 NodeId = nodeId,
                 CreatedDay = day,
+                AgeDays = 0,
                 SourceTaskId = sourceTaskId,
                 SourceAnomalyId = sourceAnomalyId,
                 IgnoreAppliedOnce = false,


### PR DESCRIPTION
### Motivation
- Support event auto-closing using the `Events.autoResolveAfterDays` field so events left in `NodeState.PendingEvents` are removed after the configured number of days without changing trigger logic, UI, or overall event system semantics.
- Keep changes minimal and local to event runtime state and the daily step path, and add grep-friendly logs to aid local verification.

### Description
- Add runtime age tracking to `EventInstance` by introducing `AgeDays` (default 0) and initialize it in `EventInstanceFactory` (file: `Assets/Scripts/Core/NodeEvents.cs` lines ~19-47). 
- Add a day-end pass `AutoResolvePendingEventsOnDayEnd` and invoke it from `Sim.StepDay` after `ApplyIgnorePenaltyOnDayEnd`; the pass iterates all `node.PendingEvents`, increments `ev.AgeDays`, and removes events where `def.autoResolveAfterDays > 0` and `ev.AgeDays >= limit` (file: `Assets/Scripts/Core/Sim.cs` lines ~136-364).
- Ensure safe removal by collecting to-remove instances first and then removing them, and keep existing ignore-apply behavior unchanged.
- Emit grep-friendly logs in the required format for per-event removal and a daily summary: `[EventAutoResolve] day=.. nodeId=.. eventDefId=.. age=.. limit=.. reason=AutoResolveAfterDays` and `[EventAutoResolve] day=.. scanned=.. removed=..`.
- Commit created with message: `feat: auto resolve pending events by days`.

### Testing
- No automated tests were executed on the modified code (no test runs performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697639856dd48322bba7b427ae8b38c8)