### PR TITLE
feat: taskdefs baseDays and agent slots

### DIFF
--- a/Assets/Scripts/Core/Sim.cs
+++ b/Assets/Scripts/Core/Sim.cs
@@ -75,9 +75,15 @@ namespace Core
                         continue;
                     }
 
-                    t.Progress = Clamp01(t.Progress + delta);
+                    int baseDays = Math.Max(1, registry.GetTaskBaseDaysWithWarn(t.Type, 1));
+                    float before = t.Progress;
+                    t.Progress = Mathf.Clamp(t.Progress + delta, 0f, baseDays);
+                    if (Math.Abs(t.Progress - before) > 0.0001f)
+                    {
+                        Debug.Log($"[TaskProgress] day={s.Day} taskId={t.Id} type={t.Type} progress={t.Progress:0.00}/{baseDays} (baseDays={baseDays})");
+                    }
 
-                    if (t.Progress >= 1f)
+                    if (t.Progress >= baseDays)
                     {
                         CompleteTask(s, n, t, rng, registry);
                     }
@@ -564,7 +570,8 @@ namespace Core
 
         static void CompleteTask(GameState s, NodeState node, NodeTask task, Random rng, DataRegistry registry)
         {
-            task.Progress = 1f;
+            int baseDays = Math.Max(1, registry.GetTaskBaseDaysWithWarn(task.Type, 1));
+            task.Progress = baseDays;
             task.State = TaskState.Completed;
             task.CompletedDay = s.Day;
 

--- a/Assets/Scripts/Runtime/GameController.cs
+++ b/Assets/Scripts/Runtime/GameController.cs
@@ -219,6 +219,7 @@ public class GameController : MonoBehaviour
             Progress = 0f,
         };
         n.Tasks.Add(t);
+        LogTaskDefSummary(TaskType.Investigate);
         GameControllerTaskExt.LogBusySnapshot(this, $"CreateInvestigateTask(node:{nodeId})");
         return t;
     }
@@ -246,6 +247,7 @@ public class GameController : MonoBehaviour
             TargetContainableId = target,
         };
         n.Tasks.Add(t);
+        LogTaskDefSummary(TaskType.Contain);
         GameControllerTaskExt.LogBusySnapshot(this, $"CreateContainTask(node:{nodeId}, target:{target})");
         return t;
     }
@@ -277,6 +279,7 @@ public class GameController : MonoBehaviour
             TargetManagedAnomalyId = target,
         };
         n.Tasks.Add(t);
+        LogTaskDefSummary(TaskType.Manage);
         GameControllerTaskExt.LogBusySnapshot(this, $"CreateManageTask(node:{nodeId}, anomaly:{target})");
         return t;
     }
@@ -334,6 +337,14 @@ public class GameController : MonoBehaviour
 
         GameControllerTaskExt.LogBusySnapshot(this, $"AssignTask(task:{taskId}, agents:{string.Join(",", agentIds)})");
         Notify();
+    }
+
+    private void LogTaskDefSummary(TaskType type)
+    {
+        var registry = DataRegistry.Instance;
+        int baseDays = registry.GetTaskBaseDaysWithWarn(type, 1);
+        var (minSlots, maxSlots) = registry.GetTaskAgentSlotRangeWithWarn(type, 1, int.MaxValue);
+        Debug.Log($"[TaskDef] taskType={type} baseDays={baseDays} slotsMin={minSlots} slotsMax={maxSlots}");
     }
 
     private void RefreshMapNodes()

--- a/Assets/Scripts/UI/NodeButton.cs
+++ b/Assets/Scripts/UI/NodeButton.cs
@@ -5,6 +5,7 @@
 using System.Linq;
 using System.Text;
 using Core;
+using Data;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -79,7 +80,7 @@ public class NodeButton : MonoBehaviour
                     if (hasSquad && t.Progress <= EPS)
                         sb.Append("\n<color=#FFD700>调查：待开始</color>");
                     else
-                        sb.Append($"\n<color=#FFD700>调查中 {(int)(t.Progress * 100)}%</color>");
+                        sb.Append($"\n<color=#FFD700>调查中 {(int)(GetTaskProgress01(t) * 100)}%</color>");
 
                     if (inv.Count > 1)
                         sb.Append($" <color=#FFD700>(+{inv.Count - 1})</color>");
@@ -95,7 +96,7 @@ public class NodeButton : MonoBehaviour
                     if (hasSquad && t.Progress <= EPS)
                         sb.Append("\n<color=#00FFFF>收容：待开始</color>");
                     else
-                        sb.Append($"\n<color=#00FFFF>收容中 {(int)(t.Progress * 100)}%</color>");
+                        sb.Append($"\n<color=#00FFFF>收容中 {(int)(GetTaskProgress01(t) * 100)}%</color>");
 
                     if (con.Count > 1)
                         sb.Append($" <color=#00FFFF>(+{con.Count - 1})</color>");
@@ -124,5 +125,12 @@ public class NodeButton : MonoBehaviour
         }
 
         if (label) label.text = sb.ToString();
+    }
+
+    private static float GetTaskProgress01(NodeTask task)
+    {
+        if (task == null) return 0f;
+        int baseDays = Mathf.Max(1, DataRegistry.Instance.GetTaskBaseDaysWithWarn(task.Type, 1));
+        return Mathf.Clamp01(task.Progress / baseDays);
     }
 }

--- a/Assets/Scripts/UI/NodePanelView.cs
+++ b/Assets/Scripts/UI/NodePanelView.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Core;
+using Data;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -345,7 +346,7 @@ public class NodePanelView : MonoBehaviour
             {
                 bool hasSquad = invMain.AssignedAgentIds != null && invMain.AssignedAgentIds.Count > 0;
                 if (hasSquad && invMain.Progress <= EPS) _invStatus.text = "状态：待开始";
-                else if (hasSquad) _invStatus.text = $"状态：进行中（{(int)(invMain.Progress * 100)}%）";
+                else if (hasSquad) _invStatus.text = $"状态：进行中（{(int)(GetTaskProgress01(invMain) * 100)}%）";
                 else _invStatus.text = "状态：未指派";
 
                 if (inv.Count > 1) _invStatus.text += $"（+{inv.Count - 1}）";
@@ -365,7 +366,7 @@ public class NodePanelView : MonoBehaviour
             {
                 bool hasSquad = conMain.AssignedAgentIds != null && conMain.AssignedAgentIds.Count > 0;
                 if (hasSquad && conMain.Progress <= EPS) _conStatus.text = "状态：待开始";
-                else if (hasSquad) _conStatus.text = $"状态：进行中（{(int)(conMain.Progress * 100)}%）";
+                else if (hasSquad) _conStatus.text = $"状态：进行中（{(int)(GetTaskProgress01(conMain) * 100)}%）";
                 else _conStatus.text = "状态：未指派";
 
                 if (con.Count > 1) _conStatus.text += $"（+{con.Count - 1}）";
@@ -750,7 +751,7 @@ public class NodePanelView : MonoBehaviour
 
         if (t.Progress <= EPS) return "状态：待开始";
 
-        return $"状态：进行中（{(int)(t.Progress * 100)}%）";
+        return $"状态：进行中（{(int)(GetTaskProgress01(t) * 100)}%）";
     }
 
     private static TaskActionMode GetActionMode(NodeTask t, bool hasSquad)
@@ -762,6 +763,14 @@ public class NodePanelView : MonoBehaviour
         if (t.Type == TaskType.Manage) return TaskActionMode.Cancel;
 
         return (t.Progress > EPS) ? TaskActionMode.Retreat : TaskActionMode.Cancel;
+    }
+
+    private static float GetTaskProgress01(NodeTask task)
+    {
+        if (task == null) return 0f;
+        if (task.Type == TaskType.Manage) return 0f;
+        int baseDays = Mathf.Max(1, DataRegistry.Instance.GetTaskBaseDaysWithWarn(task.Type, 1));
+        return Mathf.Clamp01(task.Progress / baseDays);
     }
 
     private string BuildActionLabel(TaskActionMode mode, string taskId)


### PR DESCRIPTION
### Motivation
- Integrate `TaskDefs` table fields `baseDays` and `agentSlotsMin`/`agentSlotsMax` into runtime task creation and progression so task durations and dispatch constraints are data-driven.
- Preserve existing task types and flows (Investigate/Contain/Manage) while allowing fallback to hardcoded defaults and emitting a one-time warning when a `TaskDefs` entry is missing.
- Add grep-friendly logging to aid local acceptance and verification without changing yields, events, or UI visual polish.

### Description
- Added lookup helpers and one-time missing-entry warnings in `DataRegistry` via `TryGetTaskDefForType`, `GetTaskBaseDaysWithWarn`, and `GetTaskAgentSlotRangeWithWarn`, plus a `_taskDefMissingWarned` set and `WarnMissingTaskDef` logic.
- Applied `baseDays` to task progression and completion in `Sim`: progress now advances toward `baseDays`, completion threshold is `baseDays`, and daily progress emits `[TaskProgress]` logs; `CompleteTask` sets task progress to `baseDays` when finishing.
- Log `TaskDef` summary (baseDays and slot range) on task creation in `GameController` (`LogTaskDefSummary`).
- Enforced agent slot min/max in the picker and manage flows by extending `AgentPickerView.Show` to accept `slotsMin`/`slotsMax`, validating selection counts and disabling/guarding confirm actions, with warnings on invalid selection.
- UIPanel entrypoint `UIPanelRoot.OpenPicker` queries `DataRegistry` for slot ranges and passes them to the picker when creating Investigate/Contain tasks, and `AnomalyManagePanel` reads manage slot ranges and enforces them on assignment.
- Normalize displayed progress percentages to `baseDays` in UI summaries by updating `NodePanelView` and `NodeButton` to compute progress as `Progress / baseDays`.
- Kept Manage tasks behavior (long-running, not auto-completing) unchanged except for using `baseDays` consistently for logging/representation.
- Files changed: `Assets/Scripts/Data/DataRegistry.cs`, `Assets/Scripts/Core/Sim.cs`, `Assets/Scripts/Runtime/GameController.cs`, `Assets/Scripts/UI/AgentPickerView.cs`, `Assets/Scripts/UI/UIPanelRoot.cs`, `Assets/Scripts/UI/AnomalyManagePanel.cs`, `Assets/Scripts/UI/NodePanelView.cs`, `Assets/Scripts/UI/NodeButton.cs` with commit message `"feat: taskdefs baseDays and agent slots"`.
- Added grep-able log lines: `[TaskDef] taskType=.. baseDays=.. slotsMin=.. slotsMax=..` and `[TaskProgress] day=.. taskId=.. type=.. progress=.. / .. (baseDays)`.

### Testing
- No automated tests were executed as part of this change; code changes were compiled and committed successfully (commit: `feat: taskdefs baseDays and agent slots`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763faa495883228f840c4ec5704e18)