### PR TITLE
feat: wire taskDefId and task name

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -67,6 +67,7 @@ namespace Core
         public string Id;
         public TaskType Type;
         public TaskState State = TaskState.Active;
+        public string TaskDefId;
 
         // 0..1
         public float Progress = 0f;

--- a/Assets/Scripts/Data/DataRegistry.cs
+++ b/Assets/Scripts/Data/DataRegistry.cs
@@ -105,6 +105,7 @@ namespace Data
         public Dictionary<string, NodeDef> NodesById { get; private set; } = new();
         public Dictionary<string, AnomalyDef> AnomaliesById { get; private set; } = new();
         public Dictionary<TaskType, TaskDef> TaskDefsByType { get; private set; } = new();
+        public Dictionary<string, TaskDef> TaskDefsById { get; private set; } = new();
         public Dictionary<string, EventDef> EventsById { get; private set; } = new();
         public Dictionary<string, List<EventOptionDef>> OptionsByEventId { get; private set; } = new();
         public Dictionary<string, Dictionary<string, EventOptionDef>> OptionsByEventAndId { get; private set; } = new();
@@ -218,6 +219,7 @@ namespace Data
             }
 
             TaskDefsByType = new Dictionary<TaskType, TaskDef>();
+            TaskDefsById = new Dictionary<string, TaskDef>();
             foreach (var row in Tables.GetRows("TaskDefs"))
             {
                 var taskTypeRaw = GetRowString(row, "taskType");
@@ -238,6 +240,10 @@ namespace Data
                     hasYieldPerDay = row != null && row.ContainsKey("yieldPerDay"),
                 };
                 TaskDefsByType[type] = taskDef;
+                if (!string.IsNullOrEmpty(taskDef.taskDefId))
+                {
+                    TaskDefsById[taskDef.taskDefId] = taskDef;
+                }
             }
 
             EventsById = new Dictionary<string, EventDef>();
@@ -577,6 +583,9 @@ namespace Data
 
         public bool TryGetTaskDef(TaskType type, out TaskDef def)
             => TaskDefsByType.TryGetValue(type, out def);
+
+        public TaskDef GetTaskDefById(string taskDefId)
+            => !string.IsNullOrEmpty(taskDefId) && TaskDefsById.TryGetValue(taskDefId, out var def) ? def : null;
 
         public bool TryGetTaskDefForType(TaskType type, out TaskDef def)
         {

--- a/Assets/Scripts/Runtime/GameController.cs
+++ b/Assets/Scripts/Runtime/GameController.cs
@@ -218,6 +218,7 @@ public class GameController : MonoBehaviour
             CreatedDay = State.Day,
             Progress = 0f,
         };
+        WireTaskDefOnCreate(t);
         n.Tasks.Add(t);
         LogTaskDefSummary(TaskType.Investigate);
         GameControllerTaskExt.LogBusySnapshot(this, $"CreateInvestigateTask(node:{nodeId})");
@@ -246,6 +247,7 @@ public class GameController : MonoBehaviour
             Progress = 0f,
             TargetContainableId = target,
         };
+        WireTaskDefOnCreate(t);
         n.Tasks.Add(t);
         LogTaskDefSummary(TaskType.Contain);
         GameControllerTaskExt.LogBusySnapshot(this, $"CreateContainTask(node:{nodeId}, target:{target})");
@@ -278,6 +280,7 @@ public class GameController : MonoBehaviour
             Progress = 0f,
             TargetManagedAnomalyId = target,
         };
+        WireTaskDefOnCreate(t);
         n.Tasks.Add(t);
         LogTaskDefSummary(TaskType.Manage);
         GameControllerTaskExt.LogBusySnapshot(this, $"CreateManageTask(node:{nodeId}, anomaly:{target})");
@@ -345,6 +348,26 @@ public class GameController : MonoBehaviour
         int baseDays = registry.GetTaskBaseDaysWithWarn(type, 1);
         var (minSlots, maxSlots) = registry.GetTaskAgentSlotRangeWithWarn(type, 1, int.MaxValue);
         Debug.Log($"[TaskDef] taskType={type} baseDays={baseDays} slotsMin={minSlots} slotsMax={maxSlots}");
+    }
+
+    private void WireTaskDefOnCreate(NodeTask task)
+    {
+        if (task == null) return;
+        TaskDef def = null;
+        var registry = DataRegistry.Instance;
+        if (registry != null && registry.TryGetTaskDefForType(task.Type, out def))
+        {
+            task.TaskDefId = def.taskDefId;
+        }
+        LogTaskCreate(task, def);
+    }
+
+    private static void LogTaskCreate(NodeTask task, TaskDef def)
+    {
+        if (task == null) return;
+        string taskDefId = def?.taskDefId ?? task.TaskDefId ?? "";
+        string taskDefName = def?.name ?? "";
+        Debug.Log($"[TaskCreate] taskId={task.Id} type={task.Type} taskDefId={taskDefId} name={taskDefName}");
     }
 
     private void RefreshMapNodes()

--- a/Assets/Scripts/UI/NodePanelView.cs
+++ b/Assets/Scripts/UI/NodePanelView.cs
@@ -590,13 +590,16 @@ public class NodePanelView : MonoBehaviour
             var status = GetTmp(row, "Status");
             var people = GetTmp(row, "People");
 
-            string titleTextLocal = t.Type switch
-            {
-                TaskType.Investigate => "调查",
-                TaskType.Contain => "收容",
-                TaskType.Manage => "管理",
-                _ => t.Type.ToString()
-            };
+            string taskDefLabel = ResolveTaskDefLabel(t);
+            string titleTextLocal = !string.IsNullOrEmpty(taskDefLabel)
+                ? taskDefLabel
+                : t.Type switch
+                {
+                    TaskType.Investigate => "调查",
+                    TaskType.Contain => "收容",
+                    TaskType.Manage => "管理",
+                    _ => t.Type.ToString()
+                };
             if (t.Type == TaskType.Contain)
             {
                 string tn = ResolveContainableName(node, t.TargetContainableId);
@@ -736,6 +739,14 @@ public class NodePanelView : MonoBehaviour
             if (m != null) return m.Name ?? "";
         }
         return "";
+    }
+
+    private static string ResolveTaskDefLabel(NodeTask task)
+    {
+        if (task == null) return "";
+        var def = DataRegistry.Instance != null ? DataRegistry.Instance.GetTaskDefById(task.TaskDefId) : null;
+        if (def != null && !string.IsNullOrEmpty(def.name)) return def.name;
+        return task.TaskDefId ?? "";
     }
 
     private static string BuildTaskStatusText(NodeTask t, bool hasSquad)


### PR DESCRIPTION
### Motivation
- Surface TaskDef identity and human-readable name into runtime task instances and UI so tasks can be identified in logs and panels without changing simulation numeric behavior. 
- Provide lookup by `taskDefId` in the data registry so runtime code and UI can resolve a `TaskDef` by id in addition to the existing type-based lookup. 
- Preserve existing fallback logic when a `TaskDef` is missing while emitting a single warning per task type. 

### Description
- Add `TaskDefsById` index and `GetTaskDefById(string)` to `DataRegistry` and populate it when loading `TaskDefs` from game data. 
- Extend `NodeTask` with a `TaskDefId` field to persist the matched `taskDefId`. 
- Add `WireTaskDefOnCreate(NodeTask)` and `LogTaskCreate` in `GameController`, call the wiring helper from `CreateInvestigateTask`, `CreateContainTask`, and `CreateManageTask`, and emit a `[TaskCreate] taskId=.. type=.. taskDefId=.. name=..` log on creation. 
- Update `NodePanelView` to prefer showing `TaskDef.name` (via a new `ResolveTaskDefLabel`) and fall back to `task.TaskDefId` or the previous type-localized string when name is unavailable. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976bc3bd6088322880bb6a8443679e4)