### PR TITLE
feat: wire EventTriggers condition fields

### DIFF
--- a/Assets/Scripts/Data/DataRegistry.cs
+++ b/Assets/Scripts/Data/DataRegistry.cs
@@ -80,6 +80,7 @@ namespace Data
 
     public sealed class EventTrigger
     {
+        public string RowId;
         public string EventDefId;
         public int? MinDay;
         public int? MaxDay;
@@ -342,8 +343,19 @@ namespace Data
             {
                 var eventDefId = GetRowString(row, "eventDefId");
                 if (string.IsNullOrEmpty(eventDefId)) continue;
+                var rowId = GetRowString(row, "rowId");
+                if (string.IsNullOrEmpty(rowId))
+                {
+                    rowId = GetRowString(row, "key");
+                    if (string.IsNullOrEmpty(rowId))
+                    {
+                        var rowKey = GetRowIntNullable(row, "key");
+                        rowId = rowKey?.ToString();
+                    }
+                }
                 var rowModel = new EventTriggerRow
                 {
+                    rowId = rowId,
                     eventDefId = eventDefId,
                     minDay = GetRowIntNullable(row, "minDay"),
                     maxDay = GetRowIntNullable(row, "maxDay"),
@@ -551,6 +563,7 @@ namespace Data
         {
             trigger = new EventTrigger
             {
+                RowId = string.IsNullOrEmpty(row.rowId) ? row.eventDefId : row.rowId,
                 EventDefId = row.eventDefId,
                 MinDay = row.minDay,
                 MaxDay = row.maxDay,

--- a/Assets/Scripts/Data/GameDataModels.cs
+++ b/Assets/Scripts/Data/GameDataModels.cs
@@ -125,6 +125,7 @@ namespace Data
     [Serializable]
     public class EventTriggerRow
     {
+        public string rowId;
         public string eventDefId;
         public int? minDay;
         public int? maxDay;


### PR DESCRIPTION
### Motivation
- EventTriggers table had fields that were parsed but not fully wired into event generation, so triggers did not reliably filter/match by day, node/task/anomaly conditions or bind origin IDs for generated events.

### Description
- Parse and carry a stable trigger row id by adding `rowId` to `EventTriggerRow` and `EventTrigger.RowId` and populating it during registry load (files changed: `Assets/Scripts/Data/GameDataModels.cs:125-139`, `Assets/Scripts/Data/DataRegistry.cs:341-377`, `Assets/Scripts/Data/DataRegistry.cs:562-567`).
- Replace the old event-picking path with `TryPickEventDef` that evaluates triggers via `TryGetMatchingTrigger` and a unified `TriggerMatches(...)` function to apply all specified conditions (files changed: `Assets/Scripts/Core/Sim.cs:498-540`, `Assets/Scripts/Core/Sim.cs:542-662`).
- Implement per-field rules and anomaly binding: `minDay`/`maxDay` (only apply when >0), `requiresSecured` (true means must be secured), `minLocalPanic` (>= threshold), `requiresNodeTagsAny`/`requiresNodeTagsAll` (any/all semantics), `requiresAnomalyTagsAny` (prioritize origin task anomaly, else search node-related anomalies and bind matched anomaly id), `taskType` and `onlyAffectOriginTask` (enforce origin task presence/type) and preserve existing blockPolicy semantics while binding `SourceTaskId`/`SourceAnomalyId` into created `EventInstance` (files changed: `Assets/Scripts/Core/Sim.cs:292-309`, `Assets/Scripts/Core/Sim.cs:498-725`).
- Add grep-friendly logs: daily summary `[TriggerSummary] day=.. rows=.. candidates=.. fired=..` and per-fire `[TriggerFire] day=.. rowId=.. eventDefId=.. nodeId=.. taskId=.. anomalyId=.. reason=Matched`, with optional skip logs gated by `EnableTriggerSkipLogs` (file changed: `Assets/Scripts/Core/Sim.cs:10-40`, `Assets/Scripts/Core/Sim.cs:248-252`, `Assets/Scripts/Core/Sim.cs:298-307`).

Field coverage (previous ➜ now):
- `minDay`/`maxDay`: previously not gated by >0 semantics ➜ now apply only when >0 (`Assets/Scripts/Core/Sim.cs:578-586`).
- `requiresSecured`: previously treated as a general equality ➜ now only enforces when `true` meaning node must be `Secured` (`Assets/Scripts/Core/Sim.cs:590-594`).
- `minLocalPanic`: parsed but not fully used ➜ now enforced when >0 (`Assets/Scripts/Core/Sim.cs:596-600`).
- `requiresNodeTagsAny` / `requiresNodeTagsAll`: node tag any/all logic enforced (`Assets/Scripts/Core/Sim.cs:623-631`).
- `requiresAnomalyTagsAny`: previously matched aggregated node anomaly tags only ➜ now prefers origin-task anomaly and falls back to node active/managed/containable/start anomalies and binds the matched anomaly id to the generated `EventInstance` (`Assets/Scripts/Core/Sim.cs:635-656`, `Assets/Scripts/Core/Sim.cs:650-720`).
- `taskType` / `onlyAffectOriginTask`: now require an origin task when specified and allow binding `SourceTaskId` without altering existing `blockPolicy` behavior (`Assets/Scripts/Core/Sim.cs:602-615`, `Assets/Scripts/Core/Sim.cs:616-621`).

Files changed (key locations):
- `Assets/Scripts/Core/Sim.cs` (new trigger matching and logging) — see `TryPickEventDef`/`TriggerMatches`/`TriggerFire` and `TriggerSummary` (`Sim.cs:292-309`, `Sim.cs:498-725`, `Sim.cs:240-252`).
- `Assets/Scripts/Data/DataRegistry.cs` (row id plumbing and trigger parsing) — see triggers load and `TryParseTrigger` (`DataRegistry.cs:341-377`, `DataRegistry.cs:562-567`).
- `Assets/Scripts/Data/GameDataModels.cs` (add `rowId` to `EventTriggerRow`) (`GameDataModels.cs:125-139`).

### Testing
- No automated runtime/unit tests were executed in this environment because the Unity project was not launched; changes were validated by static code edits and local repository commit which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976bf9da3d883228b450334f9fed843)