### PR TITLE
fix: triggers use requiresNodeId and events use requiresAnomalyId/taskType (remove tags)

### DIFF
--- a/Assets/Scripts/Data/GameDataModels.cs
+++ b/Assets/Scripts/Data/GameDataModels.cs
@@ -89,6 +89,8 @@ namespace Data
         public int autoResolveAfterDays;
         public string ignoreApplyMode;
         public string ignoreEffectId;
+        public string requiresAnomalyId;
+        public string requiresTaskType;
     }
 
     [Serializable]
@@ -129,9 +131,7 @@ namespace Data
         public string eventDefId;
         public int? minDay;
         public int? maxDay;
-        public List<string> requiresNodeTagsAny = new();
-        public List<string> requiresNodeTagsAll = new();
-        public List<string> requiresAnomalyTagsAny = new();
+        public string requiresNodeId;
         public bool? requiresSecured;
         public int? minLocalPanic;
         public string taskType;


### PR DESCRIPTION
### Motivation
- Replace tag-based trigger/event gating with explicit identifiers so triggers depend on `requiresNodeId` and events depend on `requiresAnomalyId`/`requiresTaskType` (both support `Any`).
- Ensure generation only fires when both Trigger conditions and EventDef conditions are satisfied, and bind `sourceTaskId`/`sourceAnomalyId` correctly to EventInstance for downstream blockPolicy/consequence logic.
- Maintain backward compatibility and resilience by treating missing new columns as `Any`, emitting one-time warnings for missing/deprecated fields, and fully ignoring deprecated tag fields at runtime.

### Description
- Added new data fields: `EventDef.requiresAnomalyId` and `EventDef.requiresTaskType` and `EventTriggerRow.requiresNodeId` in `Assets/Scripts/Data/GameDataModels.cs`.
- Updated data loading in `Assets/Scripts/Data/DataRegistry.cs` to normalize defaults (`Any`), accept the alias `requirestaskType`, emit one-time warns for missing new columns, and warn once for deprecated `requiresNodeTagsAny/All` and `requiresAnomalyTagsAny` (these are ignored at runtime).
- Replaced tag-based trigger logic with node-id matching in `TriggerMatches` and implemented `EventDefMatches` in `Assets/Scripts/Core/Sim.cs` which enforces `requiresTaskType` and `requiresAnomalyId` semantics for both node-level and task-level contexts and returns the matched anomaly id when appropriate.
- Adjusted event selection flow so a trigger only qualifies when both trigger-side checks and event-def checks pass; bound `sourceTaskId`/`sourceAnomalyId` into created `EventInstance` and expanded trigger logs (`[TriggerSummary]` and `[TriggerFire]`) to include context and requirements.
- Removed uses of tag-matching helpers from trigger flow and added helper utilities: `NormalizeRequirement`, `GetEventTaskTypeAlias`, `TableHasColumn`, and table-based warn helpers.
- Files changed: `Assets/Scripts/Data/GameDataModels.cs`, `Assets/Scripts/Data/DataRegistry.cs`, `Assets/Scripts/Core/Sim.cs` (commit message: "fix: triggers use requiresNodeId and events use requiresAnomalyId/taskType (remove tags)").

### Testing
- Performed code searches to validate removal/addition of references, specifically ran `rg -n "RequiresNodeTags|RequiresAnomalyTags|MatchesTagRequirement|AnomalyHasRequiredTags" -S Assets/Scripts/Core` which returned no matches indicating tag-based logic was removed successfully.
- Verified new-field presence via search `rg -n "requiresTaskType|requiresAnomalyId|requiresNodeId" -S Assets/Scripts` which shows the loader and runtime reference sites.
- No unit/integration test suite was executed; changes were compiled/committed locally (commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776c27640c8322af1efdd49eb771e6)