### PR TITLE
Fix DataRegistry table type reference

### DIFF
--- a/Assets/Scripts/Data/DataRegistry.cs
+++ b/Assets/Scripts/Data/DataRegistry.cs
@@ -492,7 +492,7 @@ namespace Data
         private static string NormalizeColumnName(string name)
             => string.IsNullOrWhiteSpace(name) ? string.Empty : name.Trim().ToLowerInvariant();
 
-        private static bool IsRowIdOptionalForKey(string tableName, Table table)
+        private static bool IsRowIdOptionalForKey(string tableName, GameDataTable table)
         {
             if (table?.columns == null || table.columns.Count == 0) return false;
             if (!string.Equals(tableName, "EventOptions", StringComparison.Ordinal) &&


### PR DESCRIPTION
### Motivation
- Fix compile error CS0246 caused by an incorrect `Table` type reference in `DataRegistry` by using the existing `GameDataTable` model.

### Description
- Update the method signature in `Assets/Scripts/Data/DataRegistry.cs` from `IsRowIdOptionalForKey(string tableName, Table table)` to `IsRowIdOptionalForKey(string tableName, GameDataTable table)` with no logic changes.

### Testing
- No automated tests were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697779636fe083228c5bb5af4b73f101)