### PR TITLE
Remove duplicate Serializable attribute from GameDataTable

### DIFF
--- a/Assets/Scripts/Data/GameDataModels.cs
+++ b/Assets/Scripts/Data/GameDataModels.cs
@@ -129,7 +129,6 @@ namespace Data
     }
 
     [Serializable]
-    [Serializable]
     public class GameDataTable
     {
         public string mode;


### PR DESCRIPTION
### Motivation
- Fix the compiler error `CS0579` caused by a duplicated `[Serializable]` attribute on `GameDataTable` in `Assets/Scripts/Data/GameDataModels.cs`.

### Description
- Remove the duplicated `[Serializable]` attribute declaration above the `GameDataTable` class in `Assets/Scripts/Data/GameDataModels.cs`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778a35b4008322b4da6baa589ee5a1)