### PR TITLE
feat: add NewsDefs and RandomDaily news generation (weight int, p post-pick)

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -182,9 +182,12 @@ namespace Core
 
         public List<PendingEvent> PendingEvents = new();
         public List<string> News = new();
+        public List<NewsInstance> NewsLog = new();
 
         public Dictionary<string, int> EventFiredCounts = new();
         public Dictionary<string, int> EventLastFiredDay = new();
+        public Dictionary<string, int> NewsFiredCounts = new();
+        public Dictionary<string, int> NewsLastFiredDay = new();
     }
 }
 // </EXPORT_BLOCK>

--- a/Assets/Scripts/Core/News.cs
+++ b/Assets/Scripts/Core/News.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Core
+{
+    [Serializable]
+    public class NewsInstance
+    {
+        public string Id;
+        public string NewsDefId;
+        public string NodeId;
+        public string SourceAnomalyId;
+        public string CauseType;
+        public int AgeDays;
+    }
+
+    public static class NewsInstanceFactory
+    {
+        public static NewsInstance Create(string newsDefId, string nodeId, string sourceAnomalyId, string causeType)
+        {
+            return new NewsInstance
+            {
+                Id = $"NEWS_{Guid.NewGuid():N}",
+                NewsDefId = newsDefId,
+                NodeId = nodeId,
+                SourceAnomalyId = sourceAnomalyId,
+                CauseType = causeType,
+                AgeDays = 0,
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Core/News.cs.meta
+++ b/Assets/Scripts/Core/News.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f51aa13c1ce1466cb4e7abab3dfa4bcf

--- a/Assets/Scripts/Data/GameDataModels.cs
+++ b/Assets/Scripts/Data/GameDataModels.cs
@@ -13,6 +13,7 @@ namespace Data
         public List<TaskDef> taskDefs = new();
         public List<EventDef> events = new();
         public List<EventOptionDef> eventOptions = new();
+        public List<NewsDef> newsDefs = new();
         public List<EffectDef> effects = new();
         public List<EffectOpRow> effectOps = new();
         public Dictionary<string, GameDataTable> tables = new();
@@ -106,6 +107,23 @@ namespace Data
         public string resultText;
         public List<string> affects = new();
         public string effectId;
+    }
+
+    [Serializable]
+    public class NewsDef
+    {
+        public string newsDefId;
+        public string source;
+        public int weight;
+        public float p;
+        public int minDay;
+        public int maxDay;
+        public int cd;
+        public int limitNum;
+        public string requiresNodeId;
+        public string requiresAnomalyId;
+        public string title;
+        public string desc;
     }
 
     [Serializable]

--- a/Assets/Scripts/Data/GameDataValidator.cs
+++ b/Assets/Scripts/Data/GameDataValidator.cs
@@ -30,9 +30,10 @@ namespace Data
 
             int eventsCount = GetTableRowCount(registry, "Events");
             int optionsCount = GetTableRowCount(registry, "EventOptions");
+            int newsCount = GetTableRowCount(registry, "NewsDefs");
             int effectsCount = GetTableRowCount(registry, "Effects");
             int opsCount = GetTableRowCount(registry, "EffectOps");
-            Debug.Log($"[GameDataValidator] Validation passed. events={eventsCount} options={optionsCount} effects={effectsCount} ops={opsCount}");
+            Debug.Log($"[GameDataValidator] Validation passed. events={eventsCount} options={optionsCount} news={newsCount} effects={effectsCount} ops={opsCount}");
         }
 
         private static void ValidateEnums(DataRegistry registry, List<string> errors)
@@ -70,6 +71,17 @@ namespace Data
                 var affects = GetRowStringList(opt, "affects");
                 if (!DataRegistry.TryParseAffectScopes(affects, out _, out var affectsError))
                     errors.Add(FormatCellError("EventOptions", row, "affects", string.Join(";", affects), affectsError));
+            }
+
+            var newsDefs = GetTableRows(registry, "NewsDefs");
+            for (int i = 0; i < newsDefs.Count; i++)
+            {
+                var news = newsDefs[i];
+                if (news == null) continue;
+                int row = i + 1;
+                var source = GetRowString(news, "source");
+                if (!string.IsNullOrEmpty(source) && !string.Equals(source, "RandomDaily", StringComparison.OrdinalIgnoreCase))
+                    errors.Add(FormatCellError("NewsDefs", row, "source", source, "RandomDaily"));
             }
 
             var opRows = GetTableRows(registry, "EffectOps");


### PR DESCRIPTION
### Motivation
- Introduce a data-driven, non-blocking News system (`NewsDefs`) separate from Events so informational items can be generated and persisted without touching the event pipeline.
- Support integer `weight` for weighted sampling and a post-pick probability `p` that determines whether a picked news actually emits, plus enforce `CD`/`limitNum` constraints globally per `newsDefId`.
- Ensure generated news are written to a runtime `NewsLog` and never inserted into `Node.PendingEvents`, and provide compact grep-friendly logging for verification.

### Description
- Added `NewsDef` model to `Assets/Scripts/Data/GameDataModels.cs` and wired `NewsDefs` loading in `Assets/Scripts/Data/DataRegistry.cs` with defaults, per-column one-time missing-field warnings, and `p` clamped to `[0,1]` (defaults: `weight=1`, `p=1`, `minDay/maxDay/CD/limitNum=0`, `source="RandomDaily"`, `requires*` default to `ANY`).
- Implemented runtime `NewsInstance` and `NewsInstanceFactory` in `Assets/Scripts/Core/News.cs` and added `NewsLog`, `NewsFiredCounts`, and `NewsLastFiredDay` to `GameState` in `Assets/Scripts/Core/GameState.cs`.
- Implemented `GenerateRandomDailyNews` in `Assets/Scripts/Core/Sim.cs`, including `GetRandomDailyNewsMatches`, `TryPickWeightedNews`, `UpdateNewsFireTracking`, and `AddNewsToLog`; generation runs after event generation, operates in two contexts (node+anomaly and node-only), enforces day window/CD/limitNum/weight, picks by integer weight, then rolls `p` post-pick to decide emission, and never touches `PendingEvents`.
- Added compact logging lines for per-pick decisions and daily summary: `Debug.Log` with tags `[NewsPick]`, `[NewsGen]`, and `[RandomDailyNewsSummary]` to support greppable verification, and did not modify any UI or the existing Event system semantics.

### Testing
- Ran `rg -n "PendingEvents.*News|News.*PendingEvents" Assets/Scripts` to verify news are not referenced with `PendingEvents`, which produced no matches (no link between News and PendingEvents).
- Used `rg` and file inspections to confirm new `News` loader helpers (`GetNews*WithDefault`) and `TryPickWeightedNews` were added and that `p` is clamped on load; these code inspections succeeded.
- Committed the changes (`git commit`) after edits; no automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a4c7a5cc8322971eec392ed1f876)