### PR TITLE
Reuse assignment panel for Investigate/Contain target selection

### DIFF
--- a/Assets/Scripts/Core/GameState.cs
+++ b/Assets/Scripts/Core/GameState.cs
@@ -78,6 +78,12 @@ namespace Core
         // Only for containment tasks: which containable we are trying to contain.
         public string TargetContainableId;
 
+        // Investigate: which news clue we are targeting (empty => generic investigation).
+        public string TargetNewsId;
+
+        // Investigate/Contain: anomaly id associated with this task (optional).
+        public string SourceAnomalyId;
+
         // Only for management tasks: which managed anomaly we are managing.
         public string TargetManagedAnomalyId;
 

--- a/Assets/Scripts/Core/News.cs
+++ b/Assets/Scripts/Core/News.cs
@@ -11,6 +11,8 @@ namespace Core
         public string SourceAnomalyId;
         public string CauseType;
         public int AgeDays;
+        public bool IsResolved;
+        public int ResolvedDay;
     }
 
     public static class NewsInstanceFactory
@@ -25,6 +27,8 @@ namespace Core
                 SourceAnomalyId = sourceAnomalyId,
                 CauseType = causeType,
                 AgeDays = 0,
+                IsResolved = false,
+                ResolvedDay = 0,
             };
         }
     }

--- a/Assets/Scripts/Core/Sim.cs
+++ b/Assets/Scripts/Core/Sim.cs
@@ -869,6 +869,17 @@ namespace Core
                 node.HasAnomaly = true;
 
                 s.News.Add($"- {node.Name} 调查完成：新增可收容目标 x1 ({anomalyId})");
+
+                if (!string.IsNullOrEmpty(task.TargetNewsId) && s.NewsLog != null)
+                {
+                    var news = s.NewsLog.FirstOrDefault(n => n != null && n.Id == task.TargetNewsId);
+                    if (news != null)
+                    {
+                        news.IsResolved = true;
+                        news.ResolvedDay = s.Day;
+                        Debug.Log($"[NewsResolve] day={s.Day} newsId={news.Id} nodeId={news.NodeId} anomalyId={news.SourceAnomalyId} resolved=1");
+                    }
+                }
             }
             else if (task.Type == TaskType.Contain)
             {

--- a/Assets/Scripts/Data/DataRegistry.cs
+++ b/Assets/Scripts/Data/DataRegistry.cs
@@ -745,6 +745,9 @@ namespace Data
             return dict.TryGetValue(optionId, out option);
         }
 
+        public NewsDef GetNewsDefById(string newsDefId)
+            => !string.IsNullOrEmpty(newsDefId) && NewsDefsById.TryGetValue(newsDefId, out var def) ? def : null;
+
         public bool TryGetTaskDef(TaskType type, out TaskDef def)
             => TaskDefsByType.TryGetValue(type, out def);
 

--- a/Assets/Scripts/UI/AnomalyManagePanel.cs
+++ b/Assets/Scripts/UI/AnomalyManagePanel.cs
@@ -174,9 +174,10 @@ public class AnomalyManagePanel : MonoBehaviour
         List<TargetEntry> targets,
         int agentSlotsMin,
         int agentSlotsMax,
-        Action<string, List<string>> onConfirm)
+        Action<string, List<string>> onConfirm,
+        string modeLabel = "Generic")
     {
-        ShowGenericInternal(header, hint, targets, agentSlotsMin, agentSlotsMax, onConfirm, "Generic");
+        ShowGenericInternal(header, hint, targets, agentSlotsMin, agentSlotsMax, onConfirm, modeLabel);
     }
 
     private void ShowGenericInternal(


### PR DESCRIPTION
### Motivation
- Reuse the existing `AnomalyManagePanel` UI to provide target selection (news clue or anomaly) when dispatching `Investigate`/`Contain` tasks instead of the legacy `AgentPicker` flow.
- Persist target bindings on the runtime task instance so task logic (and later UX) can reference the selected `News` or `Anomaly` for resolution, difficulty, and logging.

### Description
- Added task and news runtime fields: `NodeTask.TargetNewsId` and `NodeTask.SourceAnomalyId` in `Assets/Scripts/Core/GameState.cs`, and `NewsInstance.IsResolved`/`NewsInstance.ResolvedDay` in `Assets/Scripts/Core/News.cs`.
- Mark news resolved when an `Investigate` task that targeted a news clue completes and log a `[NewsResolve]` line, implemented in `Assets/Scripts/Core/Sim.cs` (task completion branch for `Investigate`).
- Exposed `DataRegistry.GetNewsDefById(...)` to display news titles when building target lists, added in `Assets/Scripts/Data/DataRegistry.cs`.
- Replaced the old `AgentPicker` entry points with two new flows in `Assets/Scripts/UI/UIPanelRoot.cs`: `OpenInvestigateAssignPanel()` and `OpenContainAssignPanel()`, which open `AnomalyManagePanel.ShowGeneric(...)` to present targets and slots, create tasks via `GameController.CreateInvestigateTask`/`CreateContainTask`, bind `TargetNewsId`/`SourceAnomalyId` on confirm, and call `AssignTask` to assign agents; helper builders `BuildInvestigateTargets`, `BuildContainTargets`, and `EnsureContainableForAnomaly` were added there.
- Made `AnomalyManagePanel.ShowGeneric` accept an optional `modeLabel` to distinguish `Manage` vs `Generic` usage and route logs accordingly in `Assets/Scripts/UI/AnomalyManagePanel.cs`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cec473388322934ebd3ad08ab6cd)